### PR TITLE
use persistent-sqlite >= 2.1.3

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -94,7 +94,7 @@ test-suite test
     , HUnit
     , QuickCheck
     , hspec               >= 1.8
-    , persistent-sqlite   >= 2.1
+    , persistent-sqlite   >= 2.1.3
     , persistent-template >= 2.1
     , monad-control
     , monad-logger        >= 0.3

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -40,12 +40,9 @@ import Database.Persist.MySQL ( withMySQLConn
                               , connectUser
                               , connectPassword
                               , defaultConnectInfo)
-#else
+#endif
 import Database.Persist.Sqlite (withSqliteConn)
-#if MIN_VERSION_persistent_sqlite(2,1,3)
 import Database.Sqlite (SqliteException)
-#endif
-#endif
 import Database.Persist.TH
 import Test.Hspec
 
@@ -921,12 +918,8 @@ main = do
       it "throws an exception on SQLite with <2 arguments" $
         run (select $
              from $ \p -> do
-             return (coalesce [p ^. PersonAge]) :: SqlQuery (SqlExpr (Value (Maybe Int)))
-#if MIN_VERSION_persistent_sqlite(2,1,3)
-        ) `shouldThrow` (\(_ :: SqliteException) -> True)
-#else
-        ) `shouldThrow` (\(_ :: IOException) -> True)
-#endif
+             return (coalesce [p ^. PersonAge]) :: SqlQuery (SqlExpr (Value (Maybe Int))))
+        `shouldThrow` (\(_ :: SqliteException) -> True)
 #endif
 
     describe "text functions" $ do


### PR DESCRIPTION
persistent use persistent-sqlite >= 2.1
if remove support old persistent-sqlite, we can remove ugly preprocessor.
and, text editor can detect symmetry of blacket.