### PR TITLE
Tighten version bound on base

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -63,7 +63,7 @@ library
   other-modules:
     Database.Esqueleto.Internal.PersistentImport
   build-depends:
-      base                 >= 4.5     && < 5.0
+      base                 >= 4.8     && < 5.0
     , bytestring
     , text                 >= 0.11    && < 1.3
     , persistent           >= 2.5 && < 2.7


### PR DESCRIPTION
Given that CI only seems to test against GHC 7.10 & GHC 8.0 it's safe to say that only
`base >= 4.8` is officially supported. And empirically, GHC 7.8.4 runs into the compile error below

```
Configuring component lib from esqueleto-2.5.0...
Preprocessing library esqueleto-2.5.0...
[1 of 5] Compiling Database.Esqueleto.Internal.PersistentImport ( src/Database/Esqueleto/Internal/PersistentImport.hs, /tmp/matrix-worker/1485112890/dist-newstyle/build/x86_64-linux/ghc-7.8.4/esqueleto-2.5.0/build/Database/Esqueleto/Internal/PersistentImport.o )

src/Database/Esqueleto/Internal/PersistentImport.hs:7:1: Warning:
    The import item ‘PersistQuery(..)’ suggests that
    ‘PersistQuery’ has (in-scope) constructors or class methods,
    but it has none
[2 of 5] Compiling Database.Esqueleto.Internal.Language ( src/Database/Esqueleto/Internal/Language.hs, /tmp/matrix-worker/1485112890/dist-newstyle/build/x86_64-linux/ghc-7.8.4/esqueleto-2.5.0/build/Database/Esqueleto/Internal/Language.o )

src/Database/Esqueleto/Internal/Language.hs:55:1: Warning:
    The qualified import of ‘Data.ByteString.Lazy’ is redundant
      except perhaps to import instances from ‘Data.ByteString.Lazy’
    To import instances alone, use: import Data.ByteString.Lazy()
[3 of 5] Compiling Database.Esqueleto.Internal.Sql ( src/Database/Esqueleto/Internal/Sql.hs, /tmp/matrix-worker/1485112890/dist-newstyle/build/x86_64-linux/ghc-7.8.4/esqueleto-2.5.0/build/Database/Esqueleto/Internal/Sql.o )

src/Database/Esqueleto/Internal/Sql.hs:761:32:
    Could not deduce (Functor m1) arising from a use of ‘<$>’
    from the context (SqlSelect a r, MonadIO m1, MonadIO m2)
      bound by the type signature for
                 rawSelectSource :: (SqlSelect a r, MonadIO m1, MonadIO m2) =>
                                    Mode -> SqlQuery a -> SqlReadT m1 (Acquire (C.Source m2 r))
      at src/Database/Esqueleto/Internal/Sql.hs:(753,20)-(758,57)
    or from (SqlBackendCanRead backend)
      bound by the type signature for
                 rawSelectSource :: (SqlBackendCanRead backend) =>
                                    Mode
                                    -> SqlQuery a -> R.ReaderT backend m1 (Acquire (C.Source m2 r))
      at src/Database/Esqueleto/Internal/Sql.hs:(759,1)-(778,35)
    Possible fix:
      add (Functor m1) to the context of
        the type signature for
          rawSelectSource :: (SqlBackendCanRead backend) =>
                             Mode
                             -> SqlQuery a -> R.ReaderT backend m1 (Acquire (C.Source m2 r))
        or the type signature for
             rawSelectSource :: (SqlSelect a r, MonadIO m1, MonadIO m2) =>
                                Mode -> SqlQuery a -> SqlReadT m1 (Acquire (C.Source m2 r))
    In a stmt of a 'do' block: conn <- persistBackend <$> R.ask
    In the expression:
      do { conn <- persistBackend <$> R.ask;
           res <- run conn;
           return $ (C.$= massage) `fmap` res }
    In an equation for ‘rawSelectSource’:
        rawSelectSource mode query
          = do { conn <- persistBackend <$> R.ask;
                 res <- run conn;
                 return $ (C.$= massage) `fmap` res }
          where
              run conn
                = uncurry rawQueryRes
                  $ first builderToText
                    $ toRawSql mode (conn, initialIdentState) query
              massage
                = do { mrow <- C.await;
                       .... }
              process = sqlSelectProcessRow

src/Database/Esqueleto/Internal/Sql.hs:882:26:
    Could not deduce (Functor m) arising from a use of ‘<$>’
    from the context (MonadIO m, SqlSelect a r, IsSqlBackend backend)
      bound by the type signature for
                 rawEsqueleto :: (MonadIO m, SqlSelect a r, IsSqlBackend backend) =>
                                 Mode -> SqlQuery a -> R.ReaderT backend m Int64
      at src/Database/Esqueleto/Internal/Sql.hs:(877,17)-(880,39)
    Possible fix:
      add (Functor m) to the context of
        the type signature for
          rawEsqueleto :: (MonadIO m, SqlSelect a r, IsSqlBackend backend) =>
                          Mode -> SqlQuery a -> R.ReaderT backend m Int64
    In a stmt of a 'do' block: conn <- persistBackend <$> R.ask
    In the expression:
      do { conn <- persistBackend <$> R.ask;
           uncurry rawExecuteCount
           $ first builderToText
             $ toRawSql mode (conn, initialIdentState) query }
    In an equation for ‘rawEsqueleto’:
        rawEsqueleto mode query
          = do { conn <- persistBackend <$> R.ask;
                 uncurry rawExecuteCount
                 $ first builderToText
                   $ toRawSql mode (conn, initialIdentState) query }
```