### PR TITLE
release key with selectSource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
   - stack build
   - stack test --flag esqueleto:postgresql
   - stack test --flag esqueleto:-mysql
+  - stack test
 
 cache:
   directories:

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -53,7 +53,7 @@ module Database.Esqueleto.Internal.Sql
 
 import Control.Arrow ((***), first)
 import Control.Exception (throw, throwIO)
-import Control.Monad (ap, MonadPlus(..), void)
+import Control.Monad (ap, MonadPlus(..), void, join)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Resource (MonadResource, release)
@@ -782,11 +782,14 @@ selectSource :: ( SqlSelect a r
                 , MonadResource m )
              => SqlQuery a
              -> C.Source (SqlPersistT m) r
-selectSource query = do
-  res <- lift $ rawSelectSource SELECT query
-  (key, src) <- lift $ allocateAcquire res
-  src
-  lift $ release key
+-- selectSource query = do
+--   res <- lift $ rawSelectSource SELECT query
+--   (key, src) <- lift $ allocateAcquire res
+--   src
+--   lift $ release key
+selectSource query = join . lift $ do
+  res <- rawSelectSource SELECT query
+  snd <$> allocateAcquire res
 
 -- | Execute an @esqueleto@ @SELECT@ query inside @persistent@'s
 -- 'SqlPersistT' monad and return a list of rows.

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -53,7 +53,7 @@ module Database.Esqueleto.Internal.Sql
 
 import Control.Arrow ((***), first)
 import Control.Exception (throw, throwIO)
-import Control.Monad (ap, MonadPlus(..), void, join)
+import Control.Monad (ap, MonadPlus(..), void)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Resource (MonadResource, release)

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -787,9 +787,6 @@ selectSource query = do
   (key, src) <- lift $ allocateAcquire res
   src
   lift $ release key
---  selectSource query = join . lift $ do
---    res <- rawSelectSource SELECT query
---    snd <$> allocateAcquire res
 
 -- | Execute an @esqueleto@ @SELECT@ query inside @persistent@'s
 -- 'SqlPersistT' monad and return a list of rows.

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -782,14 +782,14 @@ selectSource :: ( SqlSelect a r
                 , MonadResource m )
              => SqlQuery a
              -> C.Source (SqlPersistT m) r
--- selectSource query = do
---   res <- lift $ rawSelectSource SELECT query
---   (key, src) <- lift $ allocateAcquire res
---   src
---   lift $ release key
-selectSource query = join . lift $ do
-  res <- rawSelectSource SELECT query
-  snd <$> allocateAcquire res
+selectSource query = do
+  res <- lift $ rawSelectSource SELECT query
+  (key, src) <- lift $ allocateAcquire res
+  src
+  lift $ release key
+--  selectSource query = join . lift $ do
+--    res <- rawSelectSource SELECT query
+--    snd <$> allocateAcquire res
 
 -- | Execute an @esqueleto@ @SELECT@ query inside @persistent@'s
 -- 'SqlPersistT' monad and return a list of rows.


### PR DESCRIPTION
The current implementation of `selectSource` does not call the release key, instead waiting for the scope to end with `runResourceT`.

With the SQLite backend, this causes a runtime exception as reported in #29.

This PR introduces a test case for the problem and a solution.