### PR TITLE
Add a class for backend compatibility

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -66,14 +66,14 @@ library
       base                 >= 4.8     && < 5.0
     , bytestring
     , text                 >= 0.11    && < 1.3
-    , persistent           >= 2.7.1   && < 2.8
+    , persistent           >= 2.8.0   && < 2.9
     , transformers         >= 0.2
     , unordered-containers >= 0.2
     , tagged               >= 0.2
 
     , monad-logger
-    , conduit              >= 1.1
-    , resourcet            >= 1.1
+    , conduit              >= 1.3
+    , resourcet            >= 1.2
     , time                 >= 1.5.0.1 && <= 1.8.0.2
     , blaze-html
   hs-source-dirs: src/

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -66,7 +66,7 @@ library
       base                 >= 4.8     && < 5.0
     , bytestring
     , text                 >= 0.11    && < 1.3
-    , persistent           >= 2.5     && < 2.8
+    , persistent           >= 2.7.1   && < 2.8
     , transformers         >= 0.2
     , unordered-containers >= 0.2
     , tagged               >= 0.2

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -98,7 +98,7 @@ test-suite test
     , HUnit
     , QuickCheck
     , hspec               >= 1.8
-    , persistent-sqlite   >= 2.1.3
+    , persistent-sqlite   >= 2.8.0
     , persistent-template >= 2.1
     , monad-control
     , monad-logger        >= 0.3

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -54,19 +54,6 @@ import qualified Data.ByteString as B
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 
-class BackendCompatible sup sub where
-  projectBackend :: sub -> sup
-
-instance BackendCompatible SqlBackend SqlBackend where
-  projectBackend = id
-
-instance BackendCompatible SqlBackend SqlReadBackend where
-  projectBackend = unSqlReadBackend
-
-instance BackendCompatible SqlBackend SqlWriteBackend where
-  projectBackend = unSqlWriteBackend
-
-
 -- | Finally tagless representation of @esqueleto@'s EDSL.
 class (Functor query, Applicative query, Monad query) =>
       Esqueleto query expr backend | query -> expr backend, expr -> query backend where

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -35,6 +35,7 @@ module Database.Esqueleto.Internal.Language
     -- * The guts
   , JoinKind(..)
   , IsJoinKind(..)
+  , BackendCompatible(..)
   , PreprocessedFrom
   , From
   , FromPreprocess

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -53,6 +53,11 @@ import qualified Data.ByteString as B
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 
+class BackendCompatible sup sub
+
+instance BackendCompatible SqlBackend SqlBackend
+instance BackendCompatible SqlBackend SqlReadBackend
+instance BackendCompatible SqlBackend SqlWriteBackend
 
 -- | Finally tagless representation of @esqueleto@'s EDSL.
 class (Functor query, Applicative query, Monad query) =>
@@ -72,12 +77,12 @@ class (Functor query, Applicative query, Monad query) =>
   --   @JOIN@.
   fromStart
     :: ( PersistEntity a
-       , PersistEntityBackend a ~ backend )
+       , BackendCompatible backend (PersistEntityBackend a) )
     => query (expr (PreprocessedFrom (expr (Entity a))))
   -- | (Internal) Same as 'fromStart', but entity may be missing.
   fromStartMaybe
     :: ( PersistEntity a
-       , PersistEntityBackend a ~ backend )
+       , BackendCompatible backend (PersistEntityBackend a) )
     => query (expr (PreprocessedFrom (expr (Maybe (Entity a)))))
   -- | (Internal) Do a @JOIN@.
   fromJoin
@@ -1041,13 +1046,13 @@ class Esqueleto query expr backend => FromPreprocess query expr backend a where
 
 instance ( Esqueleto query expr backend
          , PersistEntity val
-         , PersistEntityBackend val ~ backend
+         , BackendCompatible backend (PersistEntityBackend val)
          ) => FromPreprocess query expr backend (expr (Entity val)) where
   fromPreprocess = fromStart
 
 instance ( Esqueleto query expr backend
          , PersistEntity val
-         , PersistEntityBackend val ~ backend
+         , BackendCompatible backend (PersistEntityBackend val)
          ) => FromPreprocess query expr backend (expr (Maybe (Entity val))) where
   fromPreprocess = fromStartMaybe
 

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -54,11 +54,18 @@ import qualified Data.ByteString as B
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 
-class BackendCompatible sup sub
+class BackendCompatible sup sub where
+  projectBackend :: sub -> sup
 
-instance BackendCompatible SqlBackend SqlBackend
-instance BackendCompatible SqlBackend SqlReadBackend
-instance BackendCompatible SqlBackend SqlWriteBackend
+instance BackendCompatible SqlBackend SqlBackend where
+  projectBackend = id
+
+instance BackendCompatible SqlBackend SqlReadBackend where
+  projectBackend = unSqlReadBackend
+
+instance BackendCompatible SqlBackend SqlWriteBackend where
+  projectBackend = unSqlWriteBackend
+
 
 -- | Finally tagless representation of @esqueleto@'s EDSL.
 class (Functor query, Applicative query, Monad query) =>

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -971,16 +971,22 @@ deleteCount = rawEsqueleto DELETE
 -- 'where_' $ isNothing (p '^.' PersonAge)
 -- @
 update :: ( MonadIO m
-          , SqlEntity val )
+          , SqlEntity val
+          , BackendCompatible SqlBackend backend
+          , PersistQueryWrite backend
+          , PersistUniqueWrite backend)
        => (SqlExpr (Entity val) -> SqlQuery ())
-       -> SqlWriteT m ()
+       -> R.ReaderT backend m ()
 update = void . updateCount
 
 -- | Same as 'update', but returns the number of rows affected.
 updateCount :: ( MonadIO m
-               , SqlEntity val )
+               , SqlEntity val
+               , BackendCompatible SqlBackend backend
+               , PersistQueryWrite backend
+               , PersistUniqueWrite backend)
             => (SqlExpr (Entity val) -> SqlQuery ())
-            -> SqlWriteT m Int64
+            -> R.ReaderT backend m Int64
 updateCount = rawEsqueleto UPDATE . from
 
 

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -824,9 +824,13 @@ rawSelectSource mode query =
 -- | Execute an @esqueleto@ @SELECT@ query inside @persistent@'s
 -- 'SqlPersistT' monad and return a 'C.Source' of rows.
 selectSource :: ( SqlSelect a r
-                , MonadResource m )
+               , BackendCompatible SqlBackend backend
+               , IsPersistBackend backend
+               , PersistQueryRead backend
+               , PersistStoreRead backend, PersistUniqueRead backend
+               , MonadResource m )
              => SqlQuery a
-             -> C.Source (SqlPersistT m) r
+             -> C.Source (R.ReaderT backend m) r
 selectSource query = do
   res <- lift $ rawSelectSource SELECT query
   (key, src) <- lift $ allocateAcquire res

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -970,18 +970,24 @@ deleteCount = rawEsqueleto DELETE
 -- 'set' p [ PersonAge '=.' 'just' ('val' thisYear) -. p '^.' PersonBorn ]
 -- 'where_' $ isNothing (p '^.' PersonAge)
 -- @
-update :: ( MonadIO m
-          , SqlEntity val
-          , BackendCompatible SqlBackend backend
-          , PersistQueryWrite backend
-          , PersistUniqueWrite backend)
-       => (SqlExpr (Entity val) -> SqlQuery ())
-       -> R.ReaderT backend m ()
+update
+  ::
+  ( PersistEntityBackend val ~ backend
+  , PersistEntity val
+  , PersistUniqueWrite backend
+  , PersistQueryWrite backend
+  , BackendCompatible SqlBackend backend
+  , PersistEntity val
+  , MonadIO m
+  )
+  => (SqlExpr (Entity val) -> SqlQuery ())
+  -> R.ReaderT backend m ()
 update = void . updateCount
 
 -- | Same as 'update', but returns the number of rows affected.
 updateCount :: ( MonadIO m
-               , SqlEntity val
+               , PersistEntity val
+               , PersistEntityBackend val ~ backend
                , BackendCompatible SqlBackend backend
                , PersistQueryWrite backend
                , PersistUniqueWrite backend)

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,6 +1,13 @@
 flags: {}
 packages:
 - '.'
+- location:
+    git: https://github.com/parsonsmatt/persistent
+    commit: a4f21ad5db9b65a5febf79a1be091597210a73ca
+  subdirs:
+    - persistent
+  extra-dep: true
+
 resolver: lts-6.12
 extra-deps:
-  - persistent-2.7.1
+    # - persistent-2.7.1

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -3,4 +3,4 @@ packages:
 - '.'
 resolver: lts-6.12
 extra-deps:
-  - persistent-2.5
+  - persistent-2.7.1

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -7,6 +7,7 @@ packages:
 extra-deps:
 - doctest-prop-0.2.0.1
 - quickcheck-properties-0.1
+- persistent-2.7.1
 # - http-client-0.5.0
 # - fail-4.9.0.0
 # - http-types-0.9

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -4,10 +4,17 @@ resolver: lts-8.8
 
 packages:
 - '.'
+- location:
+    git: https://github.com/parsonsmatt/persistent
+    commit: a4f21ad5db9b65a5febf79a1be091597210a73ca
+  subdirs:
+    - persistent
+  extra-dep: true
+
 extra-deps:
 - doctest-prop-0.2.0.1
 - quickcheck-properties-0.1
-- persistent-2.7.1
+  # - persistent-2.7.1
 # - http-client-0.5.0
 # - fail-4.9.0.0
 # - http-types-0.9

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -1,32 +1,36 @@
 # resolver: nightly-2017-01-10
-resolver: lts-10.0
+resolver: lts-10.4
 # compiler: ghc-8.0.2
 
 packages:
 - '.'
-- location:
-    git: https://github.com/yesodweb/persistent
-    commit: 4d0a6f3a4abde46c82691414e0e283a933a39f3e
-  extra-dep: true
-  subdirs:
-    - persistent
-    - persistent-sqlite
-- location:
-    git: https://github.com/snoyberg/conduit
-    commit: 7f75bfca8d479e1737861a75437a288af662a3cf
-  extra-dep: true
-  subdirs:
-    - conduit
-    - conduit-extra
-    - resourcet
+  # - location:
+  #     git: https://github.com/yesodweb/persistent
+  #     commit: 4d0a6f3a4abde46c82691414e0e283a933a39f3e
+  #   extra-dep: true
+  #   subdirs:
+  #     - persistent
+  #     - persistent-sqlite
+  # - location:
+  #     git: https://github.com/snoyberg/conduit
+  #     commit: 7f75bfca8d479e1737861a75437a288af662a3cf
+  #   extra-dep: true
+  #   subdirs:
+  #     - conduit
+  #     - conduit-extra
+  #     - resourcet
 
 extra-deps:
-- doctest-prop-0.2.0.1
-- quickcheck-properties-0.1
-- monad-logger-0.3.28
-- mono-traversable-1.0.8.1
-- typed-process-0.2.1.0
+    # - doctest-prop-0.2.0.1
+    # - quickcheck-properties-0.1
+    # - monad-logger-0.3.28
+    # - mono-traversable-1.0.8.1
+    # - typed-process-0.2.1.0
 - persistent-2.8.0
+- persistent-sqlite-2.8.0
+- conduit-1.3.0
+- conduit-extra-1.3.0
+- resourcet-1.2.0
   # - persistent-2.7.1
 # - http-client-0.5.0
 # - fail-4.9.0.0

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -1,0 +1,36 @@
+# resolver: nightly-2017-01-10
+resolver: lts-10.0
+# compiler: ghc-8.0.2
+
+packages:
+- '.'
+- location:
+    git: https://github.com/yesodweb/persistent
+    commit: 4d0a6f3a4abde46c82691414e0e283a933a39f3e
+  extra-dep: true
+  subdirs:
+    - persistent
+    - persistent-sqlite
+- location:
+    git: https://github.com/snoyberg/conduit
+    commit: 7f75bfca8d479e1737861a75437a288af662a3cf
+  extra-dep: true
+  subdirs:
+    - conduit
+    - conduit-extra
+    - resourcet
+
+extra-deps:
+- doctest-prop-0.2.0.1
+- quickcheck-properties-0.1
+- monad-logger-0.3.28
+- mono-traversable-1.0.8.1
+  # - persistent-2.7.1
+# - http-client-0.5.0
+# - fail-4.9.0.0
+# - http-types-0.9
+# - attoparsec-0.13.0.1
+# - doctest-0.10.1
+# - semigroups-0.18.0.1
+# - uri-bytestring-0.1.9
+# - temporary-resourcet-0.1.0.0

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -25,6 +25,8 @@ extra-deps:
 - quickcheck-properties-0.1
 - monad-logger-0.3.28
 - mono-traversable-1.0.8.1
+- typed-process-0.2.1.0
+- persistent-2.8.0
   # - persistent-2.7.1
 # - http-client-0.5.0
 # - fail-4.9.0.0

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1482,7 +1482,7 @@ insert' :: ( Functor m
 insert' v = flip Entity v <$> insert v
 
 
-type RunDbMonad m = ( MonadBaseControl IO m, MonadIO m, MonadLogger m
+type RunDbMonad m = ( R.MonadUnliftIO m, MonadIO m, MonadLogger m
                     , R.MonadThrow m )
 
 #if defined (WITH_POSTGRESQL) || defined (WITH_MYSQL)


### PR DESCRIPTION
This PR will enable Esqueleto queries to be used by the `persistent-typed-db` library, along with other database backends.

This is a WIP, please don't merge until I've had time to use it in-anger.