### PR TITLE
Adds ghci and ghcid test:sqlite entrypoints to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ test-mysql:
 	stack test esqueleto:mysql
 
 test-ghci:
-	stack ghci esqueleto:test:test
+	stack ghci esqueleto:test:sqlite
+
+test-ghcid:
+	ghcid -c "stack ghci --ghci-options -fobject-code esqueleto:test:sqlite"
 
 # sudo -u postgres createuser -s - esqueleto-test
 reset-pgsql:


### PR DESCRIPTION
`stack ghci esqueleto:test:test` just fails with the following for me:

```
stack ghci esqueleto:test:test
Error parsing targets: Component CTest "test" does not exist in package esqueleto
Note that to specify options to be passed to GHCi, use the --ghci-options flag
make: *** [test-ghci] Error 1
```

I changed it to invoke `esqueleto:test:sqlite` since that includes all the common tests.

If that's too specific, I can just add some extras for MySQL and Postgres so there are `make-test-ghci-`/`make-test-ghcid-` commands for all the backends.