### PR TITLE
Update `$GHCVER` environment variables in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
   postgresql: "9.6"
 
 env:
- - GHCVER=7.10
- - GHCVER=8.0
+ - GHCVER=8.2
+ - GHCVER=8.4
 
 install:
   - export STACK_YAML=stack-$GHCVER.yaml


### PR DESCRIPTION
If you inspect the [output](https://travis-ci.org/bitemyapp/esqueleto/jobs/411001100) from a recent travis build you'll see that the `GHCVER=7.10` and `GHCVER=8.00` values are preventing tests from actually running:

```
...

The command "stack test -- esqueleto:postgresql" exited with 1.
$ stack test -- esqueleto:sqlite
Getting project config file from STACK_YAML environment
Could not parse '/home/travis/build/bitemyapp/esqueleto/stack-8.0.yaml':
YAML exception:
Yaml file not found: /home/travis/build/bitemyapp/esqueleto/stack-8.0.yaml
See http://docs.haskellstack.org/en/stable/yaml_configuration/

...
```

I've updated to match the 8.2 and 8.4 versions that are live as of d2fdaaf.