### PR TITLE
Add `FOR UPDATE SKIP LOCKED` to possible lock types and fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - stack --version
   - echo "CREATE USER esqutest WITH PASSWORD 'esqutest';" | psql postgres
   - createdb -O esqutest esqutest
+  - mysql -e 'CREATE DATABASE esqutest;'
 
 script:
   - stack setup

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -829,6 +829,11 @@ data LockingKind =
     -- PostgreSQL.
     --
     -- /Since: 2.2.7/
+  | ForUpdateSkipLocked
+    -- ^ @FOR UPDATE SKIP LOCKED@ syntax.  Supported by MySQL, Oracle and
+    -- PostgreSQL.
+    --
+    -- /Since: 2.2.7/
   | ForShare
     -- ^ @FOR SHARE@ syntax.  Supported by PostgreSQL.
     --

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -1212,9 +1212,10 @@ makeLimit (conn, _) (Limit ml mo) orderByClauses =
 makeLocking :: LockingClause -> (TLB.Builder, [PersistValue])
 makeLocking = flip (,) [] . maybe mempty toTLB . Monoid.getLast
   where
-    toTLB ForUpdate       = "\nFOR UPDATE"
-    toTLB ForShare        = "\nFOR SHARE"
-    toTLB LockInShareMode = "\nLOCK IN SHARE MODE"
+    toTLB ForUpdate           = "\nFOR UPDATE"
+    toTLB ForUpdateSkipLocked = "\nFOR UPDATE SKIP LOCKED"
+    toTLB ForShare            = "\nFOR SHARE"
+    toTLB LockInShareMode     = "\nLOCK IN SHARE MODE"
 
 
 

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -5,5 +5,5 @@ packages:
 
 extra-deps:
 - persistent-postgresql-2.8.2.0
-- postgresql-simple-0.5.3.0
+- postgresql-simple-0.5.4.0
 allow-newer: true

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1333,9 +1333,10 @@ testLocking withConn = do
           let expected = complex <> "\n" <> syntax
           (with1, with2, with3) `shouldBe` (expected, expected, expected)
 
-    it "looks sane for ForUpdate"       $ sanityCheck ForUpdate       "FOR UPDATE"
-    it "looks sane for ForShare"        $ sanityCheck ForShare        "FOR SHARE"
-    it "looks sane for LockInShareMode" $ sanityCheck LockInShareMode "LOCK IN SHARE MODE"
+    it "looks sane for ForUpdate"           $ sanityCheck ForUpdate           "FOR UPDATE"
+    it "looks sane for ForUpdateSkipLocked" $ sanityCheck ForUpdateSkipLocked "FOR UPDATE SKIP LOCKED"
+    it "looks sane for ForShare"            $ sanityCheck ForShare            "FOR SHARE"
+    it "looks sane for LockInShareMode"     $ sanityCheck LockInShareMode     "LOCK IN SHARE MODE"
 
 
 

--- a/test/MySQL/Test.hs
+++ b/test/MySQL/Test.hs
@@ -212,7 +212,7 @@ withConn =
   R.runResourceT .
   withMySQLConn defaultConnectInfo
     { connectHost     = "localhost"
-    , connectUser     = "esqutest"
-    , connectPassword = "esqutest"
+    , connectUser     = "travis"
+    , connectPassword = ""
     , connectDatabase = "esqutest"
     }


### PR DESCRIPTION
This adds the `ForUpdateSkipLocked` to the `LockingKind` type.

Also, travis was broken for MySQL and Postgresql for the following reasons:

- The Posgresql build was failing with the following message:

``` 
        • No instance for (Semigroup Query)
            arising from the superclasses of an instance declaration
        • In the instance declaration for ‘Monoid Query’
       |
    90 | instance Monoid Query where
       |          ^^^^^^^^^^^^
```

Bumping the minor of `postgresql-simple` on `stack.yaml` fixes it.

- The MySQL build is not being able to connect to the database on the master branch. This PR fixes it.

I don't know if this is the best implementation but I am willing to change anything 😄 