### PR TITLE
Update to ghc-8.6 and persistent-2.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
 env:
  - GHCVER=8.2
  - GHCVER=8.4
+ - GHCVER=8.6
 
 install:
   - export STACK_YAML=stack-$GHCVER.yaml

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 34b1b8836c9ae7acb038d0e808674ddb4c2ab696d37e5b117f61acad02ed6daf
+-- hash: e6538d431870626b3bae78c5b1550ed237765c220c20c8eecd207e4dcd901a16
 
 name:           esqueleto
 version:        2.6.0
@@ -22,7 +24,6 @@ copyright:      (c) 2012-2016 Felipe Almeida Lessa
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
 
 source-repository head
   type: git
@@ -37,7 +38,7 @@ library
     , bytestring
     , conduit >=1.3
     , monad-logger
-    , persistent >=2.8.0 && <2.9
+    , persistent >=2.8.0 && <2.10
     , resourcet >=1.2
     , tagged >=0.2
     , text >=0.11 && <1.3
@@ -78,7 +79,7 @@ test-suite mysql
     , monad-logger
     , mysql
     , mysql-simple
-    , persistent >=2.8.0 && <2.9
+    , persistent >=2.8.0 && <2.10
     , persistent-mysql
     , persistent-template
     , resourcet >=1.2
@@ -108,7 +109,7 @@ test-suite postgresql
     , esqueleto
     , hspec
     , monad-logger
-    , persistent >=2.8.0 && <2.9
+    , persistent >=2.8.0 && <2.10
     , persistent-postgresql
     , persistent-template
     , postgresql-libpq
@@ -140,7 +141,7 @@ test-suite sqlite
     , esqueleto
     , hspec
     , monad-logger
-    , persistent >=2.8.0 && <2.9
+    , persistent >=2.8.0 && <2.10
     , persistent-sqlite
     , persistent-template
     , resourcet >=1.2

--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,7 @@ dependencies:
   - bytestring
   - conduit >=1.3
   - monad-logger
-  - persistent >=2.8.0 && <2.9
+  - persistent >=2.8.0 && <2.10
   - resourcet >=1.2
   - tagged >=0.2
   - text >=0.11 && <1.3

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -5,5 +5,5 @@ packages:
 
 extra-deps:
 - persistent-postgresql-2.8.2.0
-- postgresql-simple-0.5.3.0
+- postgresql-simple-0.5.4.0
 allow-newer: true

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -1,0 +1,5 @@
+# TODO: switch resolver to lts-13.x once that is released
+resolver: nightly-2018-12-05
+
+packages:
+- '.'


### PR DESCRIPTION
With these changes, I was able to run the following successfully on my local machine:

```
$ stack --stack-yaml stack-8.2.yaml test esqueleto\:test\:postgresql
$ stack --stack-yaml stack-8.4.yaml test esqueleto\:test\:postgresql
$ stack --stack-yaml stack-8.6.yaml test esqueleto\:test\:postgresql
```

I presume the other tests work correctly as well, but did not yet take the time to figure out how to set them up on my machine.

I made the same change to `stack-8.4.yaml` as #106 in order to run the test suite successfully for the 8.4 configuration.

Regarding #105, this change (once released) makes esqueleto compatible with the Stackage nightly builds, and therefore ready to be included in the upcoming lts-13.