### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ However, you may want your results to include people who don't have any blog pos
 ```haskell
 select $
 from $ \(p `LeftOuterJoin`` mb) -> do
-on (just (p ^. PersonId) ==. mb ?. BlogPostAuthorId)
+on (p ^. PersonId ==. mb ?. BlogPostAuthorId)
 orderBy [asc (p ^. PersonName), asc (mb ?. BlogPostTitle)]
 return (p, mb)
 ```


### PR DESCRIPTION
The application of `just` is unnecessary, and actually leads to a type error. The `?.` does all the work. ;)