### PR TITLE
Add between

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ Unreleased
 
 - @Vlix
   - [#128](https://github.com/bitemyapp/esqueleto/pull/128): Added `Database.Esqueleto.PostgreSQL.JSON` module with JSON operators and `JSONB` data type.
+- @ibarrae
+  - [#127](https://github.com/bitemyapp/esqueleto/pull/127): Added `between` and support for composite keys in `unsafeSqlBinOp`.
 
 3.0.0
 =======

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -44,7 +44,7 @@ module Database.Esqueleto
              , val, isNothing, just, nothing, joinV, withNonNull
              , countRows, count, countDistinct
              , not_, (==.), (>=.), (>.), (<=.), (<.), (!=.), (&&.), (||.)
-             , (+.), (-.), (/.), (*.)
+             , between, (+.), (-.), (/.), (*.)
              , random_, round_, ceiling_, floor_
              , min_, max_, sum_, avg_, castNum, castNumM
              , coalesce, coalesceDefault

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -466,7 +466,7 @@ a@ERaw{} `between` (ERaw p1 f, ERaw p2 g) =
     in  (parensM p1 v1 <> " AND " <> parensM p2 v2, fv ++ gv)
 a `between` (b, c)                        =
   let construct :: PersistField a => SqlExpr (Value a) -> SqlExpr (Value a)
-      construct (ERaw p f) = throw $ CompositeKeyErr BetweenError
+      construct ERaw{}            = throw $ CompositeKeyErr BetweenError
       construct (ECompositeKey f) = ERaw Parens $ \i -> (uncommas $ f i, mempty)
       valA = construct a
       valB = construct b

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1647,9 +1647,12 @@ unsafeSqlBinOp op (ERaw p1 f1) (ERaw p2 f2) = ERaw Parens f
                 , vals1 <> vals2 )
 unsafeSqlBinOp op a b = unsafeSqlBinOp op (construct a) (construct b)
     where construct :: SqlExpr (Value a) -> SqlExpr (Value a)
-          construct (ERaw p f)        = ERaw Never $ \info ->
+          construct (ERaw p f)        = ERaw Parens $ \info ->
             let (b1, vals) = f info
-             in (parensM p b1, vals)
+                build ("?", [PersistList vals']) =
+                  (uncommas $ replicate (length vals') "?", vals')
+                build expr = expr
+             in  build (parensM p b1, vals)
           construct (ECompositeKey f) =
             ERaw Parens $ \info -> (uncommas $ f info, mempty)
 {-# INLINE unsafeSqlBinOp #-}

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -457,7 +457,7 @@ not_ (ECompositeKey _) = throw (CompositeKeyErr NotError)
 
 -- | @BETWEEN@.
 --
--- /Since: 3.0.0/
+-- @since: 3.1.0
 between :: PersistField a => SqlExpr (Value a) -> (SqlExpr (Value a), SqlExpr (Value a)) -> SqlExpr (Value Bool)
 a `between` (b, c) = a >=. b &&. a <=. c
 

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -47,7 +47,7 @@ module Database.Esqueleto.Internal.Language
              , val, isNothing, just, nothing, joinV, withNonNull
              , countRows, count, countDistinct
              , not_, (==.), (>=.), (>.), (<=.), (<.), (!=.), (&&.), (||.)
-             , (+.), (-.), (/.), (*.)
+             , between, (+.), (-.), (/.), (*.)
              , random_, round_, ceiling_, floor_
              , min_, max_, sum_, avg_, castNum, castNumM
              , coalesce, coalesceDefault

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -652,18 +652,31 @@ testSelectWhere run = do
                 `between`
                   (p ^. PersonAge, p ^.  PersonWeight)
           liftIO $ ret `shouldBe` []
-      it "works for composite key values" $
-        run $ do
-          insert_ $ Point 1 2 ""
-          ret <-
-            select $
-            from $ \p -> do
-            where_ $
-              p ^. PointId
-                `between`
-                  ( EI.ECompositeKey $ const ["1", "2"]
-                  , EI.ECompositeKey $ const ["5", "6"] )
-          liftIO $ ret `shouldBe` [()]
+      describe "when projecting composite keys" $ do
+        it "works when using composite keys with val" $
+          run $ do
+            insert_ $ Point 1 2 ""
+            ret <-
+              select $
+              from $ \p -> do
+              where_ $
+                p ^. PointId
+                  `between`
+                    ( val $ PointKey 1 2
+                    , val $ PointKey 5 6 )
+            liftIO $ ret `shouldBe` [()]
+        it "works when using ECompositeKey constructor" $
+          run $ do
+            insert_ $ Point 1 2 ""
+            ret <-
+              select $
+              from $ \p -> do
+              where_ $
+                p ^. PointId
+                  `between`
+                    ( EI.ECompositeKey $ const ["3", "4"]
+                    , EI.ECompositeKey $ const ["5", "6"] )
+            liftIO $ ret `shouldBe` []
 
     it "works with avg_" $
       run $ do

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -630,6 +630,28 @@ testSelectWhere run = do
                return p
         liftIO $ ret `shouldBe` [ p3e ]
 
+    it "works for a simple example with between and [uses just . val]" $
+      run $ do
+        p1e  <- insert' p1
+        _    <- insert' p2
+        _    <- insert' p3
+        ret  <- select $
+          from $ \p -> do
+            where_ ((p ^. PersonAge) `between` (just $ val 20, just $ val 40))
+            return p
+        liftIO $ ret `shouldBe` [ p1e ]
+    it "works for a SqlExpr value with between" $
+      run $ do
+        _ <- insert' p1 >> insert' p2 >> insert' p3
+        ret <-
+          select $
+          from $ \p -> do
+          where_ $
+            just (p ^. PersonFavNum)
+              `between`
+                (p ^. PersonAge, p ^.  PersonWeight)
+        liftIO $ ret `shouldBe` []
+
     it "works with avg_" $
       run $ do
         _ <- insert' p1

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -630,27 +630,40 @@ testSelectWhere run = do
                return p
         liftIO $ ret `shouldBe` [ p3e ]
 
-    it "works for a simple example with between and [uses just . val]" $
-      run $ do
-        p1e  <- insert' p1
-        _    <- insert' p2
-        _    <- insert' p3
-        ret  <- select $
-          from $ \p -> do
-            where_ ((p ^. PersonAge) `between` (just $ val 20, just $ val 40))
-            return p
-        liftIO $ ret `shouldBe` [ p1e ]
-    it "works for a SqlExpr value with between" $
-      run $ do
-        _ <- insert' p1 >> insert' p2 >> insert' p3
-        ret <-
-          select $
-          from $ \p -> do
-          where_ $
-            just (p ^. PersonFavNum)
-              `between`
-                (p ^. PersonAge, p ^.  PersonWeight)
-        liftIO $ ret `shouldBe` []
+    describe "when using between" $ do
+      it "works for a simple example with [uses just . val]" $
+        run $ do
+          p1e  <- insert' p1
+          _    <- insert' p2
+          _    <- insert' p3
+          ret  <- select $
+            from $ \p -> do
+              where_ ((p ^. PersonAge) `between` (just $ val 20, just $ val 40))
+              return p
+          liftIO $ ret `shouldBe` [ p1e ]
+      it "works for a proyected fields value" $
+        run $ do
+          _ <- insert' p1 >> insert' p2 >> insert' p3
+          ret <-
+            select $
+            from $ \p -> do
+            where_ $
+              just (p ^. PersonFavNum)
+                `between`
+                  (p ^. PersonAge, p ^.  PersonWeight)
+          liftIO $ ret `shouldBe` []
+      it "works for composite key values" $
+        run $ do
+          insert_ $ Point 1 2 ""
+          ret <-
+            select $
+            from $ \p -> do
+            where_ $
+              p ^. PointId
+                `between`
+                  ( EI.ECompositeKey $ const ["1", "2"]
+                  , EI.ECompositeKey $ const ["5", "6"] )
+          liftIO $ ret `shouldBe` [()]
 
     it "works with avg_" $
       run $ do


### PR DESCRIPTION
Between was added by myself on #111 but it was reverted on #123 due to the fact that new `between` clause was not working with non-`val` values as @parsonsmatt mentioned [here](https://github.com/bitemyapp/esqueleto/pull/111#issuecomment-485042071).

I changed that and also included some tests to cover that case.

Please, let me know if there's another missing case so I can also address it :smiley: 