### PR TITLE
Fix LeftOuterJoin example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ However, you may want your results to include people who don't have any blog pos
 
 ```haskell
 select $
-from $ \(p `LeftOuterJoin`` mb) -> do
-on (p ^. PersonId ==. mb ?. BlogPostAuthorId)
+from $ \(p `LeftOuterJoin` mb) -> do
+on (just (p ^. PersonId) ==. mb ?. BlogPostAuthorId)
 orderBy [asc (p ^. PersonName), asc (mb ?. BlogPostTitle)]
 return (p, mb)
 ```


### PR DESCRIPTION
LeftOuterJoin example in README contains typo and doesn't type check.
This PR fixes it.