### PR TITLE
fix compile failure, add MonadUnliftIO instance to BlogT

### DIFF
--- a/examples/Blog.hs
+++ b/examples/Blog.hs
@@ -13,6 +13,7 @@ module Blog
 import           Control.Monad.Base          (MonadBase (..))
 import           Control.Monad.Logger        (MonadLogger, NoLoggingT (..))
 import           Control.Monad.Reader
+import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Control (ComposeSt, MonadBaseControl (..),
                                               MonadTransControl (..),
                                               defaultLiftBaseWith,
@@ -23,6 +24,13 @@ import           Database.Persist.Postgresql (ConnectionString)
 
 newtype BlogT m a = BlogT { unBlogT :: NoLoggingT (ReaderT ConnectionString m) a }
   deriving (Functor, Applicative, Monad, MonadLogger, MonadReader ConnectionString, MonadIO)
+
+
+-------------------------------------------------------------------------------
+instance MonadUnliftIO m => MonadUnliftIO (BlogT m) where
+  askUnliftIO = BlogT $
+                withUnliftIO $ \u ->
+                return (UnliftIO (unliftIO u . unBlogT))
 
 
 -------------------------------------------------------------------------------

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -21,6 +21,7 @@ import           Control.Monad               (void)
 import           Control.Monad               (forM_)
 import           Control.Monad.IO.Class      (MonadIO, liftIO)
 import           Control.Monad.Logger        (MonadLogger)
+import           Control.Monad.IO.Unlift     (MonadUnliftIO)
 import           Control.Monad.Reader        (MonadReader (..), runReaderT)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 import           Data.Monoid                 ((<>))
@@ -165,7 +166,7 @@ insertBlogPosts =
 
 -------------------------------------------------------------------------------
 runDB :: (MonadReader ConnectionString m,
-          MonadIO m,
+          MonadUnliftIO m,
           MonadBaseControl IO m,
           MonadLogger m)
       => SqlPersistT m a -> m a

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - monad-logger
 - monad-control
 - transformers-base
+- unliftio-core
 ghc-options:
 - -Wall
 - -threaded


### PR DESCRIPTION
Example was not working so I made a quick fix, withPostgresqlConn required BlogT to be an instance of MonadUnliftIO
Closes bitemyapp/esqueleto#140 