### PR TITLE
fix broken example in documentation

### DIFF
--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -730,8 +730,9 @@ case_ = unsafeSqlCase
 -- Bar
 --   barNum Int
 -- Foo
---   Id BarId
+--   bar BarId
 --   fooNum Int
+--   Primary bar
 -- @
 --
 -- For this example, declare:


### PR DESCRIPTION
Issue in docs is fix by just using any other variable name that is not Id or id or ID and using Primary to set the new field as key for the table