### PR TITLE
[WIP] sub_select is nullable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+Unreleased (3.2.0)
+=======
+
+- @parsonsmatt
+  - [#152](https://github.com/bitemyapp/esqueleto/pull/152): Changed the type of
+    `sub_select` to return a `Maybe`. This fixes a potential runtime error where
+    the subquery returns zero rows, resulting in a `NULL` for the expression
+    that `persistent` cannot parse.
+
 Unreleased (3.1.1)
 ========
 

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.1.0
+version:        3.2.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -64,6 +64,7 @@ module Database.Esqueleto
   , DistinctOn
   , LockingKind(..)
   , SqlString
+  , unsafePromiseNotNull
     -- ** Joins
   , InnerJoin(..)
   , CrossJoin(..)

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -350,7 +350,10 @@ locking kind = Q $ W.tell mempty { sdLockingClause = Monoid.Last (Just kind) }
 sub_select :: PersistField a => SqlQuery (SqlExpr (Value a)) -> SqlExpr (Value (Maybe a))
 sub_select         = just . sub SELECT
 
--- |
+-- | Promise that the value you have is /definitely/ not @NULL@, by some
+-- guarantee that doesn't exist in esqueleto's types.
+--
+-- @since 3.2.0
 unsafePromiseNotNull
   :: SqlExpr (Value (Maybe a))
   -> SqlExpr (Value a)

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -46,6 +46,7 @@ module Database.Esqueleto.Internal.Sql
   , unsafeSqlCastAs
   , unsafeSqlFunction
   , unsafeSqlExtractSubField
+  , unsafePromiseNotNull
   , UnsafeSqlFunctionArgument
   , OrderByClause
   , rawSelectSource


### PR DESCRIPTION
Fixes #151 

I'm going to apply this on the work codebase and see what comes up.

Alternatively, we could deprecate `sub_select` and the deprecation notice would point to `subSelect` with this type and `subSelectUnsafe` with the same type.