### PR TITLE
Insert Select With Conflict for postgres

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+Unreleased (3.1.3)
+========
+
+- @JoseD92
+  - [#155](https://github.com/bitemyapp/esqueleto/pull/149): Added `insertSelectWithConflict` postgres function.
+
 Unreleased (3.1.1)
 ========
 

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -887,6 +887,54 @@ instance ( ToSomeValues a
     toSomeValues c ++ toSomeValues d ++ toSomeValues e ++ toSomeValues f ++
     toSomeValues g ++ toSomeValues h
 
+type family KnowResult a where
+  KnowResult (i -> o) = KnowResult o
+  KnowResult a = a
+
+-- | A class for constructors or function which result type is known.
+--
+-- @since 3.1.3
+class FinalResult a where
+  finalR :: a -> KnowResult a
+
+instance FinalResult (Unique val) where
+  finalR = id
+
+instance (FinalResult b) => FinalResult (a -> b) where
+  finalR f = finalR (f undefined)
+
+-- | Convert a constructor for a 'Unique' key on a record to the 'UniqueDef' that defines it. You 
+-- can supply just the constructor itself, or a value of the type - the library is capable of figuring 
+-- it out from there.
+--
+-- @since 3.1.3
+toUniqueDef :: forall a val. (KnowResult a ~ (Unique val), PersistEntity val,FinalResult a) => 
+  a -> UniqueDef
+toUniqueDef uniqueConstructor = uniqueDef
+  where
+    proxy :: Proxy val
+    proxy = Proxy
+    unique :: Unique val
+    unique = finalR uniqueConstructor
+    -- there must be a better way to get the constrain name from a unique, make this not a list search
+    filterF = (==) (persistUniqueToFieldNames unique) . uniqueFields
+    uniqueDef = head . filter filterF . entityUniques . entityDef $ proxy
+
+-- | Render updates to be use in a SET clause for a given sql backend.
+-- 
+-- @since 3.1.3
+renderUpdates :: (BackendCompatible SqlBackend backend) => 
+    backend
+    -> [SqlExpr (Update val)]
+    -> (TLB.Builder, [PersistValue])
+renderUpdates conn = uncommas' . concatMap renderUpdate
+    where
+      mk :: SqlExpr (Value ()) -> [(TLB.Builder, [PersistValue])]
+      mk (ERaw _ f)        = [f info]
+      mk (ECompositeKey _) = throw (CompositeKeyErr MakeSetError) -- FIXME
+      renderUpdate :: SqlExpr (Update val) -> [(TLB.Builder, [PersistValue])]
+      renderUpdate (ESet f) = mk (f undefined) -- second parameter of f is always unused
+      info = (projectBackend conn, initialIdentState)
 
 -- | Data type that represents an @INNER JOIN@ (see 'LeftOuterJoin' for an example).
 data InnerJoin a b = a `InnerJoin` b

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -302,6 +302,8 @@ insertSelectWithConflict :: forall a m val. (
 insertSelectWithConflict unique query = void . insertSelectWithConflictCount unique query
 
 -- | Same as 'insertSelectWithConflict' but returns the number of rows affected.
+--
+-- @since 3.1.3
 insertSelectWithConflictCount :: forall a val m. (
     FinalResult a,
     KnowResult a ~ (Unique val), 

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -242,6 +242,11 @@ instance FinalResult (Unique val) where
 instance (FinalResult b) => FinalResult (a -> b) where
   finalR f = finalR (f undefined)
 
+-- | Convert a constructor for a 'Unique' key on a record to the 'UniqueDef' that defines it. You 
+-- can supply just the constructor itself, or a value of the type - the library is capable of figuring 
+-- it out from there.
+--
+-- @since 3.1.3
 toUniqueDef :: forall a val. (KnowResult a ~ (Unique val), PersistEntity val,FinalResult a) => 
   a -> UniqueDef
 toUniqueDef uniqueConstructor = uniqueDef

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -285,6 +285,8 @@ toUniqueDef uniqueConstructor = uniqueDef
 --
 -- Inserts to table Foo all Bar.num values and in case of conflict SomeFooUnique, 
 -- the conflicting value is updated to the current plus the excluded.
+--
+-- @since 3.1.3
 insertSelectWithConflict :: forall a m val. (
     FinalResult a,
     KnowResult a ~ (Unique val), 

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -214,6 +214,8 @@ upsertBy uniqueKey record updates = do
       (***) (f entDef (uDef :| [])) addVals $ updatesText conn
 
 -- | Render postgres updates to be use in a SET clause.
+-- 
+-- @since 3.1.3
 renderUpdates :: (BackendCompatible SqlBackend backend) => 
     backend
     -> [SqlExpr (Update val)]

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -52,6 +52,7 @@ module Common.Test
     , Circle (..)
     , Numbers (..)
     , OneUnique(..)
+    , Unique(..)
     ) where
 
 import Control.Monad (forM_, replicateM, replicateM_, void)

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -985,12 +985,12 @@ testInsertSelectWithConflict =
       _ <- insert p1
       _ <- insert p2
       _ <- insert p3
-      n1 <- EP.insertSelectWithConflictCount (UniqueValue undefined) (
+      n1 <- EP.insertSelectWithConflictCount UniqueValue (
           from $ \p -> return $ OneUnique <# val "test" <&> (p ^. PersonFavNum)
         )
         (\current excluded -> [])
       uniques1 <- select $ from $ \u -> return u
-      n2 <- EP.insertSelectWithConflictCount (UniqueValue undefined) (
+      n2 <- EP.insertSelectWithConflictCount UniqueValue (
           from $ \p -> return $ OneUnique <# val "test" <&> (p ^. PersonFavNum)
         )
         (\current excluded -> [])
@@ -1005,12 +1005,12 @@ testInsertSelectWithConflict =
         _ <- insert p2
         _ <- insert p3
         -- Note, have to sum 4 so that the update does not conflicts again with another row.
-        n1 <- EP.insertSelectWithConflictCount (UniqueValue undefined) (
+        n1 <- EP.insertSelectWithConflictCount UniqueValue (
             from $ \p -> return $ OneUnique <# val "test" <&> (p ^. PersonFavNum)
           )
           (\current excluded -> [OneUniqueValue =. val 4 +. (current ^. OneUniqueValue) +. (excluded ^. OneUniqueValue)])
         uniques1 <- select $ from $ \u -> return u
-        n2 <- EP.insertSelectWithConflictCount (UniqueValue undefined) (
+        n2 <- EP.insertSelectWithConflictCount UniqueValue (
             from $ \p -> return $ OneUnique <# val "test" <&> (p ^. PersonFavNum)
           )
           (\current excluded -> [OneUniqueValue =. val 4 +. (current ^. OneUniqueValue) +. (excluded ^. OneUniqueValue)])


### PR DESCRIPTION
Based on #86 I came with insertSelectWithConflict, it is like insertSelect but allows to perform an update if some row conflicts with the new addition on a given constraint. There is no way in postgres (that I could find) of responding to any possible conflict, so a specific one needs to be indicated with a unique.