### PR TITLE
Fix the On Clause Ordering issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
+3.2.0 (unreleased)
+=======
+
+- @parsonsmatt
+  - [#156](https://github.com/bitemyapp/esqueleto/pull/156): Remove the
+    restriction that `on` clauses must appear in reverse order to the joining
+    tables.
+
 3.1.1
-========
+=======
 
 - @JoseD92
   - [#149](https://github.com/bitemyapp/esqueleto/pull/149): Added `upsert` support.

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -32,6 +32,7 @@ library
       Database.Esqueleto.Internal.Language
       Database.Esqueleto.Internal.Sql
       Database.Esqueleto.Internal.Internal
+      Database.Esqueleto.Internal.ExprParser
       Database.Esqueleto.MySQL
       Database.Esqueleto.PostgreSQL
       Database.Esqueleto.PostgreSQL.JSON
@@ -45,9 +46,11 @@ library
   build-depends:
       base >=4.8 && <5.0
     , aeson >=1.0
+    , attoparsec >= 0.13 && < 0.14
     , blaze-html
     , bytestring
     , conduit >=1.3
+    , containers
     , monad-logger
     , persistent >=2.10.0 && <2.11
     , resourcet >=1.2
@@ -74,6 +77,7 @@ test-suite mysql
   ghc-options: -Wall
   build-depends:
       base >=4.8 && <5.0
+    , attoparsec
     , blaze-html
     , bytestring
     , conduit >=1.3
@@ -109,6 +113,7 @@ test-suite postgresql
   build-depends:
       base >=4.8 && <5.0
     , aeson
+    , attoparsec
     , blaze-html
     , bytestring
     , conduit >=1.3
@@ -143,6 +148,7 @@ test-suite sqlite
   ghc-options: -Wall
   build-depends:
       base >=4.8 && <5.0
+    , attoparsec
     , blaze-html
     , bytestring
     , conduit >=1.3

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -31,12 +31,12 @@ library
       Database.Esqueleto
       Database.Esqueleto.Internal.Language
       Database.Esqueleto.Internal.Sql
+      Database.Esqueleto.Internal.Internal
       Database.Esqueleto.MySQL
       Database.Esqueleto.PostgreSQL
       Database.Esqueleto.PostgreSQL.JSON
       Database.Esqueleto.SQLite
   other-modules:
-      Database.Esqueleto.Internal.Internal
       Database.Esqueleto.Internal.PersistentImport
       Database.Esqueleto.PostgreSQL.JSON.Instances
       Paths_esqueleto

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -86,6 +86,7 @@ test-suite mysql
     , exceptions
     , hspec
     , monad-logger
+    , mtl
     , mysql
     , mysql-simple
     , persistent >=2.8.0 && <2.11
@@ -122,6 +123,7 @@ test-suite postgresql
     , exceptions
     , hspec
     , monad-logger
+    , mtl
     , persistent >=2.10.0 && <2.11
     , persistent-postgresql >= 2.10.0 && <2.11
     , persistent-template
@@ -157,6 +159,7 @@ test-suite sqlite
     , exceptions
     , hspec
     , monad-logger
+    , mtl
     , persistent >=2.8.0 && <2.11
     , persistent-sqlite
     , persistent-template

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,6 @@ cabal-version: 1.12
 
 name:           esqueleto
 version:        3.2.0
-version:        3.1.2
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.1.1
+version:        3.2.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -325,15 +325,10 @@ import qualified Database.Persist
 -- @
 -- 'select' $
 -- 'from' $ \\(p1 `'InnerJoin`` f `'InnerJoin`` p2) -> do
--- 'on' (p2 '^.' PersonId '==.' f '^.' FollowFollowed)
 -- 'on' (p1 '^.' PersonId '==.' f '^.' FollowFollower)
+-- 'on' (p2 '^.' PersonId '==.' f '^.' FollowFollowed)
 -- return (p1, f, p2)
 -- @
---
--- /Note carefully that the order of the ON clauses is/
--- /reversed!/ You're required to write your 'on's in reverse
--- order because that helps composability (see the documentation
--- of 'on' for more details).
 --
 -- We also currently support @UPDATE@ and @DELETE@ statements.
 -- For example:

--- a/src/Database/Esqueleto/Internal/ExprParser.hs
+++ b/src/Database/Esqueleto/Internal/ExprParser.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+-- | This is an internal module. This module may have breaking changes without
+-- a corresponding major version bump. If you use this module, please open an
+-- issue with your use-case so we can safely support it.
+module Database.Esqueleto.Internal.ExprParser where
+
+import           Prelude              hiding (takeWhile)
+
+import           Control.Applicative  ((<|>))
+import           Control.Monad        (void)
+import           Data.Attoparsec.Text
+import           Data.Set             (Set)
+import qualified Data.Set             as Set
+import           Data.Text            (Text)
+import qualified Data.Text            as Text
+import           Database.Persist.Sql
+
+-- | A type representing the access of a table value. In Esqueleto, we get
+-- a guarantee that the access will look something like:
+--
+-- @
+-- escape-char [character] escape-char . escape-char [character] escape-char
+--             ^^^^^^^^^^^                           ^^^^^^^^^^^
+--             table name                            column name
+-- @
+data TableAccess = TableAccess
+  { tableAccessTable  :: Text
+  , tableAccessColumn :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+-- | Parse a @SqlExpr (Value Bool)@'s textual representation into a list of
+-- 'TableAccess'
+parseOnExpr :: SqlBackend -> Text -> Either String (Set TableAccess)
+parseOnExpr sqlBackend text = do
+  c <- mkEscapeChar sqlBackend
+  parseOnly (onExpr c) text
+
+-- | This function uses the 'connEscapeName' function in the 'SqlBackend' with an
+-- empty identifier to pull out an escape character. This implementation works
+-- with postgresql, mysql, and sqlite backends.
+mkEscapeChar :: SqlBackend -> Either String Char
+mkEscapeChar sqlBackend =
+  case Text.uncons (connEscapeName sqlBackend (DBName "")) of
+    Nothing ->
+      Left "Failed to get an escape character from the SQL backend."
+    Just (c, _) ->
+      Right c
+
+type ExprParser a = Char -> Parser a
+
+onExpr :: ExprParser (Set TableAccess)
+onExpr e = fmap Set.fromList (many' tableAccesses) <|> do
+  pure mempty
+  where
+   tableAccesses = do
+     skipToEscape e <?> "Skipping to an escape char"
+     parseTableAccess e <?> "Parsing a table access"
+
+skipToEscape :: ExprParser ()
+skipToEscape escapeChar = void (takeWhile (/= escapeChar))
+
+parseEscapedIdentifier :: ExprParser [Char]
+parseEscapedIdentifier escapeChar = do
+  char escapeChar
+  str <- parseEscapedChars escapeChar
+  char escapeChar
+  pure str
+
+parseTableAccess :: ExprParser TableAccess
+parseTableAccess ec = do
+  tableAccessTable <- Text.pack <$> parseEscapedIdentifier ec
+  _ <- char '.'
+  tableAccessColumn <- Text.pack <$> parseEscapedIdentifier ec
+  pure TableAccess {..}
+
+parseEscapedChars :: ExprParser [Char]
+parseEscapedChars escapeChar = go
+  where
+    twoEscapes = char escapeChar *> char escapeChar
+    go = many' (notChar escapeChar <|> twoEscapes)

--- a/src/Database/Esqueleto/Internal/ExprParser.hs
+++ b/src/Database/Esqueleto/Internal/ExprParser.hs
@@ -52,8 +52,7 @@ mkEscapeChar sqlBackend =
 type ExprParser a = Char -> Parser a
 
 onExpr :: ExprParser (Set TableAccess)
-onExpr e = fmap Set.fromList (many' tableAccesses) <|> do
-  pure mempty
+onExpr e = Set.fromList <$> many' tableAccesses
   where
    tableAccesses = do
      skipToEscape e <?> "Skipping to an escape char"

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1379,7 +1379,7 @@ collectOnClauses = go []
     tryMatch expr fromClause =
       case fromClause of
         FromJoin l k r onClause ->
-          matchR `mplus` matchC `mplus` matchL -- right to left
+          matchR <|> matchC <|> matchL -- right to left
             where
               matchR = (\r' -> FromJoin l k r' onClause) <$> tryMatch expr r
               matchL = (\l' -> FromJoin l' k r onClause) <$> tryMatch expr l

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -2975,7 +2975,9 @@ insertSelectCount = rawEsqueleto INSERT_INTO . fmap EInsertFinal
 
 -- | Renders an expression into 'Text'. Only useful for creating a textual
 -- representation of the clauses passed to an "On" clause.
-renderExpr :: SqlBackend -> SqlExpr (Value x) -> T.Text
+--
+-- @since 3.2.0
+renderExpr :: SqlBackend -> SqlExpr (Value Bool) -> T.Text
 renderExpr sqlBackend e =
   case e of
     ERaw _ mkBuilderValues -> do
@@ -2989,8 +2991,14 @@ renderExpr sqlBackend e =
         . mkInfo
         $ (sqlBackend, initialIdentState)
 
+-- | An exception thrown by 'RenderExpr' - it's not designed to handle composite
+-- keys, and will blow up if you give it one.
+--
+-- @since 3.2.0
 data RenderExprException = RenderExprUnexpectedECompositeKey T.Text
   deriving Show
 
+-- |
+--
+-- @since 3.2.0
 instance Exception RenderExprException
-

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -2900,7 +2900,7 @@ insertSelectCount = rawEsqueleto INSERT_INTO . fmap EInsertFinal
 
 -- | Renders an expression into 'Text'. Only useful for creating a textual
 -- representation of the clauses passed to an "On" clause.
-renderExpr :: MonadIO m => SqlExpr (Value Bool) -> SqlPersistT m T.Text
+renderExpr :: MonadIO m => SqlExpr (Value x) -> SqlPersistT m T.Text
 renderExpr e = do
   sqlBackend <- R.ask
   case e of

--- a/src/Database/Esqueleto/Internal/Sql.hs
+++ b/src/Database/Esqueleto/Internal/Sql.hs
@@ -55,6 +55,7 @@ module Database.Esqueleto.Internal.Sql
   , Mode(..)
   , NeedParens(..)
   , IdentState
+  , renderExpr
   , initialIdentState
   , IdentInfo
   , SqlSelect(..)
@@ -71,6 +72,7 @@ module Database.Esqueleto.Internal.Sql
   , parens
   , toArgList
   , builderToText
+  , Ident(..)
   ) where
 
 import Database.Esqueleto.Internal.Internal

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1498,11 +1498,14 @@ testRenderSql run = do
 
   describe "renderExpr" $ do
     it "renders a value" $ do
-      run $ do
-        expr <- EI.renderExpr $
+      expr <- run $
+        EI.renderExpr $
           EI.EEntity (EI.I "user") ^. PersonId
           ==. EI.EEntity (EI.I "blog_post") ^. BlogPostAuthorId
-        liftIO $ expr `shouldBe` "\"user\".\"id\" = \"blog_post\".\"authorId\""
+      expr `shouldBe` "\"user\".\"id\" = \"blog_post\".\"authorId\""
+    it "renders ? for a val" $ do
+      expr <- run $ EI.renderExpr (val (PersonKey 0) ==. val (PersonKey 1))
+      expr `shouldBe` "? = ?"
 
 
 tests :: Run -> Spec

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1843,6 +1843,21 @@ testOnClauseOrder run = describe "On Clause Ordering" $ do
       listsEqualOn ac ca $ \(Entity _ a, b) ->
         (joinOneName a, maybe "NULL" (joinOtherName . entityVal) b)
 
+    it "doesn't require an on for a crossjoin" $ do
+      void $ run $
+        select $
+        from $ \(a `CrossJoin` b) -> do
+        pure (a :: SqlExpr (Entity JoinOne), b :: SqlExpr (Entity JoinTwo))
+
+    it "errors with an on for a crossjoin" $ do
+      (void $ run $
+        select $
+        from $ \(a `CrossJoin` b) -> do
+        on $ a ^. JoinOneId ==. b ^. JoinTwoJoinOne
+        pure (a, b))
+          `shouldThrow` \(OnClauseWithoutMatchingJoinException _) ->
+            True
+
     it "left joins associativity" $ do
       ca <- run $ do
         setup

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -100,6 +100,10 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
     title String
     authorId PersonId
     deriving Eq Show
+  Comment
+    body String
+    blog BlogPostId
+    deriving Eq Show
 
   Lord
     county String maxlen=100
@@ -159,6 +163,7 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
   Numbers
     int    Int
     double Double
+
 |]
 
 -- Unique Test schema
@@ -315,6 +320,7 @@ testSelectFrom run = do
                                                     , (p1e, p2e)
                                                     , (p2e, p1e)
                                                     , (p2e, p2e) ]
+
 
     it "works for a self-join via sub_select" $
       run $ do
@@ -826,6 +832,16 @@ testSelectWhere run = do
                                 , (p1e, f12, p2e)
                                 , (p4e, f42, p2e)
                                 , (p2e, f21, p1e) ]
+
+    it "works for a many-to-many explicit join and on order doesn't matter" $
+      run $ do
+        ret <- select $
+               from $ \(person `InnerJoin` blog `InnerJoin` comment) -> do
+               on $ person ^. PersonId ==. blog ^. BlogPostAuthorId
+               on $ blog ^. BlogPostId ==. comment ^. CommentBlog
+               pure (person, comment)
+
+        liftIO $ True `shouldBe` True
 
     it "works for a many-to-many explicit join with LEFT OUTER JOINs" $
       run $ do

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1476,7 +1476,7 @@ testCountingRows run = do
           liftIO $ (n :: Int) `shouldBe` expected
 
 testRenderSql :: Run -> Spec
-testRenderSql run =
+testRenderSql run = do
   describe "testRenderSql" $ do
     it "works" $ do
       (queryText, queryVals) <- run $ renderQuerySelect $
@@ -1496,6 +1496,13 @@ testRenderSql run =
         `shouldBe`
           [toPersistValue ("Johhny Depp" :: TL.Text)]
 
+  describe "renderExpr" $ do
+    it "renders a value" $ do
+      run $ do
+        expr <- EI.renderExpr $
+          EI.EEntity (EI.I "user") ^. PersonId
+          ==. EI.EEntity (EI.I "blog_post") ^. BlogPostAuthorId
+        liftIO $ expr `shouldBe` "\"user\".\"id\" = \"blog_post\".\"authorId\""
 
 
 tests :: Run -> Spec

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -958,10 +958,10 @@ testInsertUniqueViolation =
       insert u3) `shouldThrow` (==) exception
   where
     exception = SqlError {
-      sqlState = "23505", 
-      sqlExecStatus = FatalError, 
-      sqlErrorMsg = "duplicate key value violates unique constraint \"UniqueValue\"", 
-      sqlErrorDetail = "Key (value)=(0) already exists.", 
+      sqlState = "23505",
+      sqlExecStatus = FatalError,
+      sqlErrorMsg = "duplicate key value violates unique constraint \"UniqueValue\"",
+      sqlErrorDetail = "Key (value)=(0) already exists.",
       sqlErrorHint = ""}
 
 testUpsert :: Spec


### PR DESCRIPTION
This PR tracks my attempt to fix the on clause ordering issue.

[Previous discussion here](https://github.com/bitemyapp/esqueleto/issues/49#issuecomment-545223824).

TLDR on implementation plan:

- Render the `OnClause (SqlExpr (Value Bool))` into `Text` (lmao)
- Parse the `Text` and find table identifiers - we pretty much have a guarnatee that they'll have the grammar:
    ```
    escape-char [character] escape-char . escape-char [character] escape-char
    ```
    which should make it relatively straightforward to write a parser that will return all the `Ident`s for the `OnClause`.
- Once we have the identifiers associated with the `OnClause`, we can be more selective about finding the appropriate match. The `FromClause` that gets constructed is a binary tree with nodes of `FromClause lhs JoinKind rhs (Maybe OnClause)` and leaves of `FromStart Ident EntityDef`. The binary tree gets associated to the left (so it's really more like a list).
- The right-most `FromStart` is meant to be the base of the join, so it's name does not need to be in the `OnClause` for the top-level `FromJoin`.

# Longer form implementation plan

```haskell
from $ \(a `InnerJoin` b `InnerJoin` c) -> do
on (c ^. CBId ==. b ^. BId)
on (b ^. BAId ==. a ^. AId)
```

This will generate a `[FromClause]` like this:

```haskell
[ FromClause ...
, OnClause ...
, OnClause ...
]
```

That `FromClause` will be shaped like this:

```
                 FromJoin 
                /        \
            FromJoin      FromStart A
           /        \
FromStart C         FromStart B
```

You might look at this and think, "Ah, a degenerate tree - let's just make it a list!" Unfortunately, Esqueleto supports arbitrary nesting of joins, in part to make composability better.

We'd start at the top: `FromJoin lhs rhs`. We want the left-most leaf of `rhs` and the right-most leaf of `lhs`. This is easy for the first `FromJoin` because the `rhs` is a `FromStart`. It has the table identifier `a`. For the next, we get into the `lhs`, which is another `FromJoin`. We descend to the right, and we get to a `FromStart` with an identifier `b`. 

Now, we'll go and render/parse our OnClauses. We take our first `OnClause`, and we render it into `"c"."b_id" = "b"."b_id"`. We can parse out the two table identifiers - `"c"` and `"b"`. This doesn't match. So we render/parse the second one, which gives us `"b"."a_id" = "a"."id"` and the idents `a` and `b`. This is a match. So we can associate *this* `OnClause` with the top-level `FromJoin`.

Now, we need to find the "next" `FromJoin`. The initial case will always be `FromJoin rhs FromStart`. It gets more complex here. The "next" `FromJoin` is going to be a `FromJoin` that has a `FromStart` as the RHS, and should be the rightmost one. In this simple case, we'd descend into the second `FromJoin` and check the RHS - it's a `FromStart`, so we're good. Search the `OnClause`s, find the matching table identifiers, and we're set.

Aside: Oh hell, that's not necessarily going to work.
There's *two* ways to produce a `SqlExpr (Value (Key a))` - `entity ^. persistIdField` BUT ALSO `val (SomeKey a)`, which would render out to a mere `?`.
Well, I think that this approach may be dead in the water :(

Anyway, the algorithm is basically:

1. Find the rightmost `FromJoin` that has a `FromStart` as the immediate RHS (and does not already have an `OnClause`).
2. Find it's rightmost `FromStart` in the left branch.
3. Assign the `on` clause with matching table identifiers.
4. Set the `OnClause` for the `FromJoin` in step 1 to the `SqlExpr` that was rendered to produce that.
5. Descend into the LHS.
6. Go back to 1, terminate if there are no matches.

So. Hm. How can we handle the case where it's a `E.val someKey :: SqlExpr (Value (Key SomeEntity))`?
Let's verify how it renders:

```haskell
    it "renders ? for a val" $ do
      expr <- run $ EI.renderExpr (val (PersonKey 0) ==. val (PersonKey 1))
      expr `shouldBe` "? = ?"
```

This is an *abuse* of `ON`, IMO - this sort of query would look like:

```sql
SELECT *
FROM foo
INNER JOIN bar
ON bar.foo_id = 3
  -- where 3 is assumed to be an ID of a Foo that we care about
;
```

While this is syntactically correct SQL, it's really more appropriate to write this as:

```sql
SELECT *
FROM foo
INNER JOIN bar
ON bar.foo_id = foo.id
WHERE foo.id = 3
;
```

Another potentially weird set of JOINs are like this:

```sql
SELECT *
FROM foo
INNER JOIN bar
ON true
```

which is exactly equivalent to a cross join.

```sql
SELECT *
FROM foo
LEFT JOIN bar
ON false
```

which is going to produce nothin but NULLs for the `bar`s.
Nevertheless, these are definitely syntactically valid, so we should consider them.
For the most part, these correspond to "things that fail to parse into at least a pair of table identifiers."

We have 53 uses of `on` in the work codebase, and none use anything funky or weird - all are standard.
So I feel pretty confident that this algorithm will work well for most cases.
As a fallback, we can run the current algorithm again after performing the smarter matching, which ... should probably pick out the right things.
Or possibly fail, but I think this will be well worth the pain.
