### PR TITLE
Add several common SQL string functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.3.0
+========
+
+- @charukiewicz, @belevy, @joemalin95
+  - [#166](https://github.com/bitemyapp/esqueleto/pull/166): Add several common SQL string functions: `upper_`, `trim_`, `ltrim_`, `rtrim_`, `length_`, `left_`, `right_`
+
 3.2.3
 ========
 

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.2.3
+version:        3.3.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -681,6 +681,41 @@ coalesceDefault exprs = unsafeSqlFunctionParens "COALESCE" . (exprs ++) . return
 lower_ :: SqlString s => SqlExpr (Value s) -> SqlExpr (Value s)
 lower_  = unsafeSqlFunction "LOWER"
 
+-- | @UPPER@ function.
+-- /Since: 3.3.0/
+upper_ :: SqlString s => SqlExpr (Value s) -> SqlExpr (Value s)
+upper_  = unsafeSqlFunction "UPPER"
+
+-- | @TRIM@ function.
+-- /Since: 3.3.0/
+trim_ :: SqlString s => SqlExpr (Value s) -> SqlExpr (Value s)
+trim_  = unsafeSqlFunction "TRIM"
+
+-- | @RTRIM@ function.
+-- /Since: 3.3.0/
+rtrim_ :: SqlString s => SqlExpr (Value s) -> SqlExpr (Value s)
+rtrim_  = unsafeSqlFunction "RTRIM"
+
+-- | @LTRIM@ function.
+-- /Since: 3.3.0/
+ltrim_ :: SqlString s => SqlExpr (Value s) -> SqlExpr (Value s)
+ltrim_  = unsafeSqlFunction "LTRIM"
+
+-- | @LENGTH@ function.
+-- /Since: 3.3.0/
+length_ :: (SqlString s, Num a) => SqlExpr (Value s) -> SqlExpr (Value a)
+length_ = unsafeSqlFunction "LENGTH"
+
+-- | @LEFT@ function.
+-- /Since: 3.3.0/
+left_ :: (SqlString s, Num a) => (SqlExpr (Value s), SqlExpr (Value a)) -> SqlExpr (Value s)
+left_ = unsafeSqlFunction "LEFT"
+
+-- | @RIGHT@ function.
+-- /Since: 3.3.0/
+right_ :: (SqlString s, Num a) => (SqlExpr (Value s), SqlExpr (Value a)) -> SqlExpr (Value s)
+right_ = unsafeSqlFunction "RIGHT"
+
 -- | @LIKE@ operator.
 like :: SqlString s => SqlExpr (Value s) -> SqlExpr (Value s) -> SqlExpr (Value Bool)
 like    = unsafeSqlBinOp    " LIKE "


### PR DESCRIPTION
This PR adds several common SQL string functions we noticed were not implemented in the library:
- UPPER
- TRIM
- LTRIM
- RTRIM
- LENGTH
- LEFT
- RIGHT

------------

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
