### PR TITLE
Update (^.) to fix natural key handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.3.2
+========
+
+- @belevy
+  - [#177](https://github.com/bitemyapp/esqueleto/pull/177) Fix natural key handling in (^.)
+
 3.3.1.1
 ========
 

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.3.1.1
+version:        3.3.2
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -2345,6 +2345,7 @@ cleanDB = do
   delete $ from $ \(_ :: SqlExpr (Entity CcList))  -> return ()
 
   delete $ from $ \(_ :: SqlExpr (Entity ArticleTag)) -> return ()
+  delete $ from $ \(_ :: SqlExpr (Entity ArticleMetadata)) -> return ()
   delete $ from $ \(_ :: SqlExpr (Entity Article))    -> return ()
   delete $ from $ \(_ :: SqlExpr (Entity Article2))   -> return ()
   delete $ from $ \(_ :: SqlExpr (Entity Tag))        -> return ()

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -168,7 +168,7 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
   ArticleMetadata
     articleId ArticleId
     Primary articleId
-    deriving Show
+    deriving Eq Show
   Tag
     name String maxlen=100
     Primary name
@@ -762,11 +762,11 @@ testSelectJoin run = do
         let number = 101
         insert_ $ Frontcover number ""
         articleId <- insert $ Article "title" number
-        insertKey (ArticleMetadataKey articleId) (ArticleMetadata articleId)
-        xs <- select . from $ \articleMetadata -> do
+        articleMetaE <- insert' (ArticleMetadata articleId)
+        result <- select . from $ \articleMetadata -> do
           where_ $ (articleMetadata ^. ArticleMetadataId) ==. (val ((ArticleMetadataKey articleId)))
           pure articleMetadata
-        pure ()
+        liftIO $ [articleMetaE] `shouldBe` result
     it "works with a ForeignKey to a non-id primary key returning both entities" $
       run $ do
         let fc = Frontcover number ""

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -165,6 +165,10 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
     frontcoverNumber Int
     Foreign Frontcover fkfrontcover frontcoverNumber
     deriving Eq Show
+  ArticleMetadata
+    articleId ArticleId
+    Primary articleId
+    deriving Show
   Tag
     name String maxlen=100
     Primary name
@@ -753,7 +757,16 @@ testSelectJoin run = do
         liftIO $ do
           retFc `shouldBe` fc
           fcPk `shouldBe` thePk
-
+    it "allows using a primary key that is itself a key of another table" $
+      run $ do
+        let number = 101
+        insert_ $ Frontcover number ""
+        articleId <- insert $ Article "title" number
+        insertKey (ArticleMetadataKey articleId) (ArticleMetadata articleId)
+        xs <- select . from $ \articleMetadata -> do
+          where_ $ (articleMetadata ^. ArticleMetadataId) ==. (val ((ArticleMetadataKey articleId)))
+          pure articleMetadata
+        pure ()
     it "works with a ForeignKey to a non-id primary key returning both entities" $
       run $ do
         let fc = Frontcover number ""


### PR DESCRIPTION
Update the handling of id fields in the projection operator. Since persistent treats all natural keys as composite keys we can not rely on hasCompositeKey. 

Instead use entityKeyFields to treat surrogate and single field natural keys the same. 

Fixes #176 