### PR TITLE
Address Nullability and SQL operators

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -33,6 +33,7 @@ library
       Database.Esqueleto.Internal.Sql
       Database.Esqueleto.Internal.Internal
       Database.Esqueleto.Internal.ExprParser
+      Database.Esqueleto.Internal.SqlTypeable
       Database.Esqueleto.MySQL
       Database.Esqueleto.PostgreSQL
       Database.Esqueleto.PostgreSQL.JSON
@@ -60,6 +61,7 @@ library
     , transformers >=0.2
     , unliftio
     , unordered-containers >=0.2
+    , vector
   if impl(ghc >=8.0)
     ghc-options: -Wall -Wno-redundant-constraints
   else

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -53,7 +53,7 @@ module Database.Esqueleto
              , subList_select, valList, justList
              , in_, notIn, exists, notExists
              , set, (=.), (+=.), (-=.), (*=.), (/=.)
-             , case_, toBaseId
+             , case_, toBaseId, coerce_
   , subSelect
   , subSelectMaybe
   , subSelectCount

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -8,7 +8,6 @@
            , TypeFamilies
            , UndecidableInstances
            , GADTs
-           , AllowAmbiguousTypes
  #-}
 {-# LANGUAGE ConstraintKinds
            , EmptyDataDecls

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -648,7 +648,7 @@ ceiling_ = unsafeSqlFunction "CEILING"
 floor_   :: (PersistField a, Num a, PersistField b, Num b) => SqlExpr (Value a) -> SqlExpr (Value b)
 floor_   = unsafeSqlFunction "FLOOR"
 
-sum_     :: (PersistField a) => SqlExpr (Value a) -> SqlExpr (Value (SqlMaybe a))
+sum_     :: (PersistField a, PersistField b) => SqlExpr (Value a) -> SqlExpr (Value (Maybe b))
 sum_     = unsafeSqlFunction "SUM"
 min_     :: (PersistField a)  => SqlExpr (Value a) -> SqlExpr (Value (SqlMaybe a))
 min_     = unsafeSqlFunction "MIN"

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -568,7 +568,7 @@ nothing = unsafeSqlValue "NULL"
 
 -- | Join nested 'Maybe's in a 'Value' into one. This is useful when
 -- calling aggregate functions on nullable fields.
-joinV :: SqlExpr (Value (Maybe typ)) -> SqlExpr (Value typ)
+joinV :: SqlExpr (Value (Maybe (Maybe typ))) -> SqlExpr (Value (Maybe typ))
 joinV = veryUnsafeCoerceSqlExprValue
 
 -- | @COUNT(*)@ value.

--- a/src/Database/Esqueleto/Internal/Language.hs
+++ b/src/Database/Esqueleto/Internal/Language.hs
@@ -57,6 +57,7 @@ module Database.Esqueleto.Internal.Language
              , in_, notIn, exists, notExists
              , set, (=.), (+=.), (-=.), (*=.), (/=.)
              , case_, toBaseId, (<#), (<&>)
+             , coerce_
   , subSelect
   , subSelectMaybe
   , subSelectCount

--- a/src/Database/Esqueleto/Internal/SqlTypeable.hs
+++ b/src/Database/Esqueleto/Internal/SqlTypeable.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE DataKinds
+           , FlexibleContexts
+           , FlexibleInstances
+           , UndecidableInstances
+           , TypeFamilies
+ #-}
+module Database.Esqueleto.Internal.SqlTypeable where
+
+import qualified Data.ByteString as B
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import Text.Blaze.Html (Html)
+import Data.Fixed
+import Data.Int
+import qualified Data.IntMap as IM
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Data.Time (UTCTime, TimeOfDay, Day)
+import qualified Data.Vector as V
+import Data.Word
+import Numeric.Natural (Natural)
+
+import Database.Esqueleto.Internal.PersistentImport
+
+{--
+   SqlTypeable should have an instance for every PersistFieldSql instance. Ultimately it would be good to merge the classes. Contains a type level sqlType function and a SqlNullable associated type that is True iff null can inhabit the type
+ --}
+class PersistFieldSql t => SqlTypeable t where
+  -- What is the underlying SqlType of the provided type t
+  type SqlType' t :: SqlType
+  -- Whether null can inhabit t
+  type SqlNullable t :: Bool
+
+instance (PersistFieldSql (Maybe t), SqlTypeable t, SqlNullable t ~ 'False) => SqlTypeable (Maybe t) where
+  type SqlType' (Maybe t) = SqlType' t
+  type SqlNullable (Maybe t) = 'True
+instance (PersistFieldSql (Key t)) => SqlTypeable (Key t) where
+  type SqlType' (Key t) = 'SqlInt64
+  type SqlNullable (Key t) = 'False
+instance {-# OVERLAPPABLE #-} SqlTypeable t => SqlTypeable [t] where
+  type SqlType' [t] = 'SqlString
+  type SqlNullable [t] = 'False
+instance SqlTypeable [Char] where
+  type SqlType' [Char] = 'SqlString
+  type SqlNullable [Char] = 'False
+instance SqlTypeable T.Text where
+  type SqlType' T.Text = 'SqlString
+  type SqlNullable T.Text = 'False
+instance SqlTypeable TL.Text where
+  type SqlType' TL.Text = 'SqlString
+  type SqlNullable TL.Text = 'False
+instance SqlTypeable B.ByteString where
+  type SqlType' B.ByteString = 'SqlBlob
+  type SqlNullable B.ByteString = 'False
+instance SqlTypeable Html where
+  type SqlType' Html = 'SqlString
+  type SqlNullable Html = 'False
+instance SqlTypeable Bool where
+  type SqlType' Bool = 'SqlBool
+  type SqlNullable Bool = 'False
+instance SqlTypeable Int where
+  type SqlType' Int = 'SqlInt64
+  type SqlNullable Int = 'False
+instance SqlTypeable Double where
+  type SqlType' Double = 'SqlReal
+  type SqlNullable Double = 'False
+instance SqlTypeable Int8 where
+  type SqlType' Int8 = 'SqlInt32
+  type SqlNullable Int8 = 'False
+instance SqlTypeable Int16 where
+  type SqlType' Int16 = 'SqlInt32
+  type SqlNullable Int16 = 'False
+instance SqlTypeable Int32 where
+  type SqlType' Int32 = 'SqlInt32
+  type SqlNullable Int32 = 'False
+instance SqlTypeable Int64 where
+  type SqlType' Int64 = 'SqlInt64
+  type SqlNullable Int64 = 'False
+instance SqlTypeable Word where
+  type SqlType' Word = 'SqlInt64
+  type SqlNullable Word = 'False
+instance SqlTypeable Word8 where
+  type SqlType' Word8 = 'SqlInt32
+  type SqlNullable Word8 = 'False
+instance SqlTypeable Word16 where
+  type SqlType' Word16 = 'SqlInt32
+  type SqlNullable Word16 = 'False
+instance SqlTypeable Word32 where
+  type SqlType' Word32 = 'SqlInt64
+  type SqlNullable Word32 = 'False
+instance SqlTypeable Word64 where
+  type SqlType' Word64 = 'SqlInt64
+  type SqlNullable Word64 = 'False
+instance SqlTypeable Day where
+  type SqlType' Day = 'SqlDay
+  type SqlNullable Day = 'False
+instance SqlTypeable TimeOfDay where
+  type SqlType' TimeOfDay = 'SqlTime
+  type SqlNullable TimeOfDay = 'False
+instance SqlTypeable UTCTime where
+  type SqlType' UTCTime = 'SqlDayTime
+  type SqlNullable UTCTime = 'False
+instance SqlTypeable a => SqlTypeable (V.Vector a) where
+  type SqlType' (V.Vector a) = 'SqlString
+  type SqlNullable (V.Vector a) = 'False
+instance (Ord a, SqlTypeable a) => SqlTypeable (S.Set a) where
+  type SqlType' (S.Set a) = 'SqlString
+  type SqlNullable (S.Set a) = 'False
+instance (SqlTypeable a, SqlTypeable b) => SqlTypeable (a,b) where
+  type SqlType' (a, b) = 'SqlString
+  type SqlNullable (a, b) = 'False
+instance SqlTypeable v => SqlTypeable (IM.IntMap v) where
+  type SqlType' (IM.IntMap v) = 'SqlString
+  type SqlNullable (IM.IntMap v) = 'False
+instance SqlTypeable v => SqlTypeable (M.Map T.Text v) where
+  type SqlType' (M.Map T.Text v) = 'SqlString
+  type SqlNullable (M.Map T.Text v) = 'False
+instance SqlTypeable PersistValue where
+  type SqlType' PersistValue = 'SqlInt64 -- since PersistValue should only be used like this for keys, which in SQL are Int64
+  type SqlNullable PersistValue = 'False
+instance SqlTypeable Checkmark where
+  type SqlType' Checkmark = 'SqlBool
+  type SqlNullable Checkmark = 'False
+{-- TODO: How do we implement SqlNumeric. Should we have a new type that mirrors the persistent SQL Type?
+instance SqlTypeable Rational where
+  type SqlType' Rational = 'SqlNumeric 32 20
+  type SqlNullable Rational = 'False
+  --}
+instance SqlTypeable Natural where
+  type SqlType' Natural = 'SqlInt64
+  type SqlNullable Natural = 'False
+-- An embedded Entity
+instance (PersistField record, PersistEntity record) => SqlTypeable (Entity record) where
+  type SqlType' (Entity record) = 'SqlString
+  type SqlNullable (Entity record) = 'False

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -944,7 +944,7 @@ testSelectWhere run = do
         _ <- insert' p4
         ret <- select $
                from $ \p->
-               return $ joinV $ avg_ (p ^. PersonAge)
+               return $ avg_ (p ^. PersonAge)
         let testV :: Double
             testV = roundTo (4 :: Integer) $ (36 + 17 + 17) / (3 :: Double)
 
@@ -960,7 +960,7 @@ testSelectWhere run = do
         _ <- insert' p4
         ret <- select $
                from $ \p->
-               return $ joinV $ min_ (p ^. PersonAge)
+               return $ min_ (p ^. PersonAge)
         liftIO $ ret `shouldBe` [ Value $ Just (17 :: Int) ]
 
     it "works with max_" $
@@ -971,7 +971,7 @@ testSelectWhere run = do
         _ <- insert' p4
         ret <- select $
                from $ \p->
-               return $ joinV $ max_ (p ^. PersonAge)
+               return $ max_ (p ^. PersonAge)
         liftIO $ ret `shouldBe` [ Value $ Just (36 :: Int) ]
 
     it "works with lower_" $

--- a/test/MySQL/Test.hs
+++ b/test/MySQL/Test.hs
@@ -46,7 +46,7 @@ testMysqlSum = do
       _ <- insert' p4
       ret <- select $
              from $ \p->
-             return $ joinV $ sum_ (p ^. PersonAge)
+             return $ sum_ (p ^. PersonAge)
       liftIO $ ret `shouldBe` [ Value $ Just (36 + 17 + 17 :: Double ) ]
 
 

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -27,6 +27,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (getCurrentTime, diffUTCTime, UTCTime)
 import Database.Esqueleto hiding (random_)
+import Database.Esqueleto.Internal.Internal (IsSqlBool)
 import qualified Database.Esqueleto.Internal.Sql as ES
 import Database.Esqueleto.PostgreSQL (random_)
 import qualified Database.Esqueleto.PostgreSQL as EP
@@ -1062,8 +1063,8 @@ sqlFailWith errState f = do
         errStateT = TE.decodeUtf8 errState
 
 selectJSONwhere
-  :: MonadIO m
-  => (JSONBExpr A.Value -> SqlExpr (Value Bool))
+  :: (MonadIO m, IsSqlBool bool)
+  => (JSONBExpr A.Value -> SqlExpr (Value bool))
   -> SqlPersistT m [Entity Json]
 selectJSONwhere f = selectJSON $ where_ . f
 

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -156,7 +156,7 @@ testPostgresqlSum = do
       _ <- insert' p4
       ret <- select $
              from $ \p->
-             return $ joinV $ sum_ (p ^. PersonAge)
+             return $ sum_ (p ^. PersonAge)
       liftIO $ ret `shouldBe` [ Value $ Just (36 + 17 + 17 :: Rational ) ]
 
 

--- a/test/SQLite/Test.hs
+++ b/test/SQLite/Test.hs
@@ -44,7 +44,7 @@ testSqliteSum = do
       _ <- insert' p4
       ret <- select $
              from $ \p->
-             return $ joinV $ sum_ (p ^. PersonAge)
+             return $ sum_ (p ^. PersonAge)
       liftIO $ ret `shouldBe` [ Value $ Just (36 + 17 + 17 :: Int) ]
 
 


### PR DESCRIPTION
This PR attempts to remove the major pain points of esqueleto nullability. I could not figure out a way to make the type inference play nicely with functions that accept either a type or its variant but that probably could be resolved with a Proxy type class similar to SqlString. However, this would remove the need to use joinV in most cases as the operators will already flatten the maybes using the SqlMaybe type class and also removes the need to use COALESCE before using boolean operators. 