### PR TITLE
Postgresql Date Truncation

### DIFF
--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -2592,6 +2592,8 @@ cleanDB = do
   delete $ from $ \(_ :: SqlExpr (Entity JoinOne))    -> return ()
   delete $ from $ \(_ :: SqlExpr (Entity JoinOther))    -> return ()
 
+  delete $ from $ \(_ :: SqlExpr (Entity DateTruncTest)) -> pure ()
+
 
 cleanUniques
   :: (forall m. RunDbMonad m

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -528,7 +528,12 @@ testPostgresModule = do
             expectationFailure "index not found"
           Just (original, expected) -> do
             utcTime `shouldBe` original
-            utcTime `shouldBe` expected
+            if utctDay utcTime == utctDay expected
+              then
+                utctDay utcTime `shouldBe` utctDay expected
+              else
+                -- use this if/else to get a beter error message
+                utcTime `shouldBe` expected
 
   describe "PostgreSQL module" $ do
     describe "Aggregate functions" testAggregateFunctions


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->

This PR includes a test for date truncation in postgresql. 

Fixes #27 

The observed behavior is somewhat weird on my machine locally:

```
  test/PostgreSQL/Test.hs:536:17:
  1) PostgreSQL specific tests, date_trunc, works
       Falsifiable (after 3 tests and 4 shrinks):
         [(0,0,0,0)]
       expected: 1999-12-31 07:00:00 UTC
        but got: 2000-01-01 00:00:00 UTC
```

The date is generated from this:

```haskell
    prop "works" $ \listOfDateParts -> run $ do
      let
        utcTimes =
          map
            (\(y, m, d, s) ->
              fromInteger s
                `addUTCTime`
                  UTCTime (fromGregorian (2000 + y) m d) 0
            )
          listOfDateParts
```

So it's weird to me that we get a 07:00:00 at all! We're inserting `UTCTime (fromGregorian 2000 0 0) 0`, which becomes `2000-01-01 00:00:00 UTC`. So why are we getting `1999-12-31 07:00:00 UTC` back from Postgres?

It would appear that the time zone shift is occurring with `date_trunc`, because the value round trips out of the database just fine.

May be relevant: https://www.postgresqltutorial.com/postgresql-timestamp/