### PR TITLE
Bugfix rollup: Fix issue with extra characters in generated SQL; Fix ToAliasReference for already referenced values; Fix Alias/Reference for Maybe Entity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,10 @@
-3.3.3.4
+3.3.3.3
 =======
 - @belevy
   - [#191](https://github.com/bitemyapp/esqueleto/pull/191) - Bugfix rollup: 
     Fix issue with extra characters in generated SQL;
     Fix ToAliasReference for already referenced values; 
     Fix Alias/Reference for Maybe Entity 
-
-3.3.3.3
-=======
 - @maxgabriel
   - [#203](https://github.com/bitemyapp/esqueleto/pull/203) Document `isNothing`
 - @sestrella

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+3.3.3.3
+========
+- @belevy
+  - [#191](https://github.com/bitemyapp/esqueleto/pull/191) - Fix issue with extra characters in generated SQL
+
 3.3.3.2
 ========
 - @maxgabriel

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 3.3.3.3
 ========
 - @belevy
-  - [#191](https://github.com/bitemyapp/esqueleto/pull/191) - Fix issue with extra characters in generated SQL
+  - [#191](https://github.com/bitemyapp/esqueleto/pull/191) - Bugfix rollup: 
+    Fix issue with extra characters in generated SQL; 
+    Fix ToAliasReference for already referenced values; 
+    Fix Alias/Reference for Maybe Entity 
 
 3.3.3.2
 ========

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.3.3.2
+version:        3.3.3.3
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.3.3.4
+version:        3.3.3.3
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -684,6 +684,7 @@ from parts = do
 type family ToAliasT a where
   ToAliasT (SqlExpr (Value a)) = SqlExpr (Value a)
   ToAliasT (SqlExpr (Entity a)) = SqlExpr (Entity a)
+  ToAliasT (SqlExpr (Maybe (Entity a))) = SqlExpr (Maybe (Entity a))
   ToAliasT (a, b) = (ToAliasT a, ToAliasT b)
   ToAliasT (a, b, c) = (ToAliasT a, ToAliasT b, ToAliasT c)
   ToAliasT (a, b, c, d) = (ToAliasT a, ToAliasT b, ToAliasT c, ToAliasT d)
@@ -708,6 +709,9 @@ instance ToAlias (SqlExpr (Entity a)) where
   toAlias (EEntity tableIdent) = do
     ident <- newIdentFor (DBName "v")
     pure $ EAliasedEntity ident tableIdent
+
+instance ToAlias (SqlExpr (Maybe (Entity a))) where
+  toAlias (EMaybe e) = EMaybe <$> toAlias e
 
 instance (ToAlias a, ToAlias b) => ToAlias (a,b) where
   toAlias (a,b) = (,) <$> toAlias a <*> toAlias b
@@ -767,6 +771,7 @@ instance ( ToAlias a
 type family ToAliasReferenceT a where
   ToAliasReferenceT (SqlExpr (Value a)) = SqlExpr (Value a)
   ToAliasReferenceT (SqlExpr (Entity a)) = SqlExpr (Entity a)
+  ToAliasReferenceT (SqlExpr (Maybe (Entity a))) = SqlExpr (Maybe (Entity a))
   ToAliasReferenceT (a,b) = (ToAliasReferenceT a, ToAliasReferenceT b)
   ToAliasReferenceT (a,b,c) = (ToAliasReferenceT a, ToAliasReferenceT b, ToAliasReferenceT c)
   ToAliasReferenceT (a, b, c, d) = (ToAliasReferenceT a, ToAliasReferenceT b, ToAliasReferenceT c, ToAliasReferenceT d)
@@ -790,6 +795,8 @@ instance ToAliasReference (SqlExpr (Entity a)) where
   toAliasReference _ e@(EEntity _) = toAlias e
   toAliasReference s   (EAliasedEntityReference _ b) = pure $ EAliasedEntityReference s b
 
+instance ToAliasReference (SqlExpr (Maybe (Entity a))) where
+  toAliasReference s (EMaybe e) = EMaybe <$> toAliasReference s e
 instance (ToAliasReference a, ToAliasReference b) => ToAliasReference (a, b) where
   toAliasReference ident (a,b) = (,) <$> (toAliasReference ident a) <*> (toAliasReference ident b)
 

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -783,12 +783,12 @@ instance ToAliasReference (SqlExpr (Value a)) where
   toAliasReference aliasSource (EAliasedValue aliasIdent _) = pure $ EValueReference aliasSource (\_ -> aliasIdent)
   toAliasReference _           v@(ERaw _ _)                 = toAlias v
   toAliasReference _           v@(ECompositeKey _)          = toAlias v
-  toAliasReference _           v@(EValueReference _ _)      = pure v
+  toAliasReference s             (EValueReference _ b)      = pure $ EValueReference s b
 
 instance ToAliasReference (SqlExpr (Entity a)) where
   toAliasReference aliasSource (EAliasedEntity ident _) = pure $ EAliasedEntityReference aliasSource ident
   toAliasReference _ e@(EEntity _) = toAlias e
-  toAliasReference _ e@(EAliasedEntityReference _ _) = pure e
+  toAliasReference s   (EAliasedEntityReference _ b) = pure $ EAliasedEntityReference s b
 
 instance (ToAliasReference a, ToAliasReference b) => ToAliasReference (a, b) where
   toAliasReference ident (a,b) = (,) <$> (toAliasReference ident a) <*> (toAliasReference ident b)

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -894,6 +894,21 @@ testSelectSubQuery run = do
         ret <- select $ Experimental.from $ SelectQuery q
         liftIO $ ret `shouldBe` [ (Value $ personName p1, Value $ personAge p1) ]
 
+    it "supports sub-selecting Maybe entities" $ do
+      run $ do
+        l1 <- insert' l1
+        l3 <- insert' l3
+        l1Deeds <- mapM (\k -> insert' $ Deed k (entityKey l1)) (map show [1..3 :: Int])
+        let l1WithDeeds = do d <- l1Deeds
+                             pure (l1, Just d)
+        ret <- select $ Experimental.from $ SelectQuery $ do
+          (lords :& deeds) <-
+              Experimental.from $ Table @Lord
+              `LeftOuterJoin` Table @Deed
+              `Experimental.on` (\(l :& d) -> just (l ^. LordId) ==. d ?. DeedOwnerId)
+          pure (lords, deeds)
+        liftIO $ ret `shouldMatchList` ((l3, Nothing) : l1WithDeeds)
+
     it "lets you order by alias" $ do
       run $ do
         _ <- insert' p1

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -896,18 +896,18 @@ testSelectSubQuery run = do
 
     it "supports sub-selecting Maybe entities" $ do
       run $ do
-        l1 <- insert' l1
-        l3 <- insert' l3
-        l1Deeds <- mapM (\k -> insert' $ Deed k (entityKey l1)) (map show [1..3 :: Int])
+        l1e <- insert' l1
+        l3e <- insert' l3
+        l1Deeds <- mapM (\k -> insert' $ Deed k (entityKey l1e)) (map show [1..3 :: Int])
         let l1WithDeeds = do d <- l1Deeds
-                             pure (l1, Just d)
+                             pure (l1e, Just d)
         ret <- select $ Experimental.from $ SelectQuery $ do
           (lords :& deeds) <-
               Experimental.from $ Table @Lord
               `LeftOuterJoin` Table @Deed
               `Experimental.on` (\(l :& d) -> just (l ^. LordId) ==. d ?. DeedOwnerId)
           pure (lords, deeds)
-        liftIO $ ret `shouldMatchList` ((l3, Nothing) : l1WithDeeds)
+        liftIO $ ret `shouldMatchList` ((l3e, Nothing) : l1WithDeeds)
 
     it "lets you order by alias" $ do
       run $ do


### PR DESCRIPTION
`in_` was generating invalid mysql statements by double wrapping value lists. This existed before 3.3.3.1. Also fixed an issue with the generated value names in subqueries getting "`"s erroneously added for each nesting

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

