### PR TITLE
Add new SetOperation constructor for parenthesized query

### DIFF
--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -9,6 +9,7 @@
            , TypeFamilies
            , UndecidableInstances
            , OverloadedStrings
+           , PatternSynonyms
  #-}
 
 module Database.Esqueleto.Experimental
@@ -23,7 +24,8 @@ module Database.Esqueleto.Experimental
 
       -- * Documentation
 
-      SqlSetOperation(..)
+      SqlSetOperation(Union, UnionAll, Except, Intersect)
+    , pattern SelectQuery
     , From(..)
     , on
     , from
@@ -68,7 +70,8 @@ import Database.Esqueleto.Internal.Internal
           , to3, to4, to5, to6, to7, to8
           , from3, from4, from5, from6, from7, from8
           , veryUnsafeCoerceSqlExprValue
-          , parens
+          , parensM
+          , NeedParens(..)
           )
 import GHC.TypeLits
 
@@ -380,8 +383,10 @@ data SqlSetOperation a =
   | UnionAll (SqlSetOperation a) (SqlSetOperation a)
   | Except (SqlSetOperation a) (SqlSetOperation a)
   | Intersect (SqlSetOperation a) (SqlSetOperation a)
-  | SelectQuery  (SqlQuery a)
-  | SelectQueryP (SqlQuery a)
+  | SelectQueryP NeedParens (SqlQuery a)
+
+pattern SelectQuery :: SqlQuery a -> SqlSetOperation a
+pattern SelectQuery q = SelectQueryP Never q
 
 -- | Data type that represents the syntax of a 'JOIN' tree. In practice,
 -- only the @Table@ constructor is used directly when writing queries. For example,
@@ -464,8 +469,7 @@ instance {-# OVERLAPPABLE #-} ToFrom (FullOuterJoin a b) where
 
 instance (SqlSelect a' r,SqlSelect a'' r', ToAlias a, a' ~ ToAliasT a, ToAliasReference a', ToAliasReferenceT a' ~ a'')  => ToFrom (SqlSetOperation a) where
   -- If someone uses just a plain SelectQuery it should behave like a normal subquery
-  toFrom (SelectQuery q) = SubQuery q
-  toFrom (SelectQueryP q) = SubQuery q
+  toFrom (SelectQueryP _ q) = SubQuery q
   -- Otherwise use the SqlSetOperation
   toFrom q = SqlSetOperation q
 
@@ -620,23 +624,21 @@ from parts = do
           where
             aliasQueries o =
               case o of
-                SelectQuery q -> do
+                SelectQueryP p q -> do
                   (ret, sideData) <- Q $ W.censor (\_ -> mempty) $ W.listen $ unQ q
                   prevState <- Q $ lift S.get
                   aliasedRet <- toAlias ret
                   Q $ lift $ S.put prevState
-                  let selectConstructor = if    (sdLimitClause sideData) /= mempty 
-                                             || length (sdOrderByClause sideData) > 0 then
-                                            SelectQueryP
-                                          else 
-                                            SelectQuery
-                  pure (selectConstructor $ Q $ W.WriterT $ pure (aliasedRet, sideData), aliasedRet)
-                SelectQueryP q -> do
-                  (ret, sideData) <- Q $ W.censor (\_ -> mempty) $ W.listen $ unQ q
-                  prevState <- Q $ lift S.get
-                  aliasedRet <- toAlias ret
-                  Q $ lift $ S.put prevState
-                  pure (SelectQueryP $ Q $ W.WriterT $ pure (aliasedRet, sideData), aliasedRet)
+                  let p' =
+                        case p of
+                          Parens -> Parens
+                          Never ->
+                            if (sdLimitClause sideData) /= mempty
+                                || length (sdOrderByClause sideData) > 0 then
+                              Parens
+                            else
+                              Never
+                  pure (SelectQueryP p' $ Q $ W.WriterT $ pure (aliasedRet, sideData), aliasedRet)
                 Union     o1 o2 -> do
                   (o1', ret) <- aliasQueries o1
                   (o2', _  ) <- aliasQueries o2
@@ -656,10 +658,9 @@ from parts = do
 
             operationToSql o info =
               case o of
-                SelectQuery q   -> toRawSql SELECT info q
-                SelectQueryP q  -> 
+                SelectQueryP p q  ->
                   let (builder, values) = toRawSql SELECT info q
-                  in (parens builder, values)
+                  in (parensM p builder, values)
                 Union     o1 o2 -> doSetOperation "UNION"     info o1 o2
                 UnionAll  o1 o2 -> doSetOperation "UNION ALL" info o1 o2
                 Except    o1 o2 -> doSetOperation "EXCEPT"    info o1 o2

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1863,6 +1863,7 @@ type OrderByClause = SqlExpr OrderBy
 
 -- | A @LIMIT@ clause.
 data LimitClause = Limit (Maybe Int64) (Maybe Int64)
+  deriving Eq
 
 instance Semigroup LimitClause where
   Limit l1 o1 <> Limit l2 o2 =
@@ -2019,6 +2020,7 @@ data SqlExpr a where
 data InsertFinal
 
 data NeedParens = Parens | Never
+   deriving Eq
 
 parensM :: NeedParens -> TLB.Builder -> TLB.Builder
 parensM Never  = id


### PR DESCRIPTION
This is a potential fix for #194. I am not sure that I like the extra SelectQueryP constructor but I don't want to muddy up the api for others and cant really think of a nicer way to convey the information. 

I guess theoretically aliasQuery could use a different data type that is exactly the same but with SelectQuery taking a NeedParens. 
I don't know if that is better or worse, do we want to expose the ability to add parentheses to the user directly?

I am certainly not tied to this, in fact it seems super hacky but so is mysql. I think this is probably better than depending on connRDBMS == "mysql". 