### PR TITLE
Lateral joins

### DIFF
--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -537,7 +537,7 @@ instance {-# OVERLAPPABLE #-} ToFrom (LeftOuterJoin a b) where
   toFrom = undefined
 instance {-# OVERLAPPABLE #-} ToFrom (RightOuterJoin a b) where
   toFrom = undefined
-instance {-# OVERLAPPABLE #-} ToFrom (a b) where
+instance {-# OVERLAPPABLE #-} ToFrom (FullOuterJoin a b) where
   toFrom = undefined
 
 instance ToFrom (From a) where


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

------

Fixes #121 

I am not particularly happy with the extra *Lateral constructors on the From GADT. If you can come up with a better way please do. 
Once again the TypeError's have caused so many headaches. Because they need the catchall overlappable instances the only way I could satisfy the compiler was by making new classes with an extra type parameter that is generated using the IsLateral type family. Once again I am very open to suggestions on how to make this implementation less awful but I like the syntax for the end user.