### PR TITLE
Common table expressions

### DIFF
--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -891,7 +891,7 @@ testSelectSubQuery run = do
         let q = do
                 p <- Experimental.from $ Table @Person
                 return ( p ^. PersonName, p ^. PersonAge)
-        ret <- select $ Experimental.from $ SelectQuery q
+        ret <- select $ Experimental.from q
         liftIO $ ret `shouldBe` [ (Value $ personName p1, Value $ personAge p1) ]
 
     it "supports sub-selecting Maybe entities" $ do
@@ -901,7 +901,7 @@ testSelectSubQuery run = do
         l1Deeds <- mapM (\k -> insert' $ Deed k (entityKey l1e)) (map show [1..3 :: Int])
         let l1WithDeeds = do d <- l1Deeds
                              pure (l1e, Just d)
-        ret <- select $ Experimental.from $ SelectQuery $ do
+        ret <- select $ Experimental.from $ do
           (lords :& deeds) <-
               Experimental.from $ Table @Lord
               `LeftOuterJoin` Table @Deed
@@ -976,7 +976,7 @@ testSelectSubQuery run = do
         mapM_ (\k -> insert $ Deed k l3k) (map show [4..10 :: Int])
         let q = do
                 (lord :& deed) <- Experimental.from $ Table @Lord
-                        `InnerJoin` (SelectQuery $ Experimental.from $ Table @Deed)
+                        `InnerJoin` (Experimental.from $ Table @Deed)
                         `Experimental.on` (\(lord :& deed) ->
                                              lord ^. LordId ==. deed ^. DeedOwnerId)
                 groupBy (lord ^. LordId)
@@ -991,10 +991,9 @@ testSelectSubQuery run = do
         l3k <- insert l3
         let q = do
                 (lord :& (_, dogCounts)) <- Experimental.from $ Table @Lord
-                        `LeftOuterJoin` (SelectQuery $ do
-                                      lord <- Experimental.from $ Table @Lord
-                                      pure (lord ^. LordId, lord ^. LordDogs)
-                                   )
+                        `LeftOuterJoin` do
+                            lord <- Experimental.from $ Table @Lord
+                            pure (lord ^. LordId, lord ^. LordDogs)
                         `Experimental.on` (\(lord :& (lordId, _)) ->
                                              just (lord ^. LordId) ==. lordId)
                 groupBy (lord ^. LordId, dogCounts)

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1164,7 +1164,7 @@ testCommonTableExpressions = do
               lords <- Experimental.from $ Experimental.Table @Lord
               limit 10
               pure lords
-          lords <- limitedLordsCte
+          lords <- Experimental.from limitedLordsCte
           orderBy [asc $ lords ^. LordId]
           pure lords
 
@@ -1176,7 +1176,7 @@ testCommonTableExpressions = do
                      (pure $ val (1 :: Int))
                      Experimental.unionAll_
                      (\self -> do
-                         v <- self
+                         v <- Experimental.from self
                          where_ $ v <. val 10
                          pure $ v +. val 1
                      )
@@ -1184,8 +1184,8 @@ testCommonTableExpressions = do
       select $ do
         cte <- oneToTen
         cte2 <- oneToTen
-        res1 <- cte
-        res2 <- cte2
+        res1 <- Experimental.from cte
+        res2 <- Experimental.from cte2
         pure (res1, res2)
     vals `shouldBe` (((,) <$> fmap Value [1..10] <*> fmap Value [1..10]))
 
@@ -1196,14 +1196,14 @@ testCommonTableExpressions = do
            (pure $ val (1 :: Int))
            Experimental.unionAll_
            (\self -> do
-               v <- self
+               v <- Experimental.from self
                where_ $ v <. val 10
                pure $ v +. val 1
            )
-      oneMore :: SqlQuery (SqlExpr (Value Int)) -> SqlQuery (SqlQuery (SqlExpr (Value Int)))
+
       oneMore q =
         Experimental.with $ do
-          v <- q
+          v <- Experimental.from q
           pure $ v +. val 1
     in do
     vals <- run $ do
@@ -1211,7 +1211,7 @@ testCommonTableExpressions = do
       select $ do
         cte <- oneToTen
         cte2 <- oneMore cte
-        res <- cte2
+        res <- Experimental.from cte2
         pure res
     vals `shouldBe` fmap Value [2..11]
 


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)


========================================

TODO 
   can we get a more unified syntactic style between the recursive cte `unionAll_`/`union_` and `UnionAll`/`Union`
   documentation
   this may be broken af
@parsonsmatt have fun 