### PR TITLE
Use type families instead of empty classes

### DIFF
--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -660,7 +660,7 @@ data From a where
 
 -- | Constraint for `on`. Ensures that only types that require an `on` can be used on
 -- the left hand side. This was previously reusing the ToFrom class which was actually
--- a bit too lenient as it allowed to much. Expanding this type family should not be needed.
+-- a bit too lenient as it allowed to much.
 --
 -- @since 3.4.0.0
 type family ValidOnClauseValue a :: Constraint where


### PR DESCRIPTION
An idea I had while looking through the changes. Not sure if this breaks compatibility with a ghc, but it seems more "minimalistic" and I think it shouldn't be a breaking API change.

@belevy 