### PR TITLE
Also export ValidOnClauseValue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.4.1.0
+=======
+- @Vlix
+  - [#232](https://github.com/bitemyapp/esqueleto/pull/232)
+    - Export the `ValidOnClauseValue` type family
+
 3.4.0.1
 =======
 - @arthurxavierx

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.4.0.1
+version:        3.4.1.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -57,6 +57,7 @@ module Database.Esqueleto.Experimental
     , ToAliasT
     , ToAliasReference(..)
     , ToAliasReferenceT
+    , ValidOnClauseValue
     -- * The Normal Stuff
 
     , where_


### PR DESCRIPTION
This is a constraint on `on`, but not exported, so you have to go into the source to see what it does. Exporting makes this easier.

(I don't think any `ChangeLog` or version edits are necessary for this)