### PR TITLE
Fix non-exhaustive patterns in 'unsafeSqlAggregateFunction'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.4.0.2
+=======
+- @arthurxavierx
+  - [#238](https://github.com/bitemyapp/esqueleto/pull/238)
+    - Fix non-exhaustive patterns in `unsafeSqlAggregateFunction`
+
 3.4.0.1
 =======
 - @arthurxavierx

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.4.0.1
+version:        3.4.0.2
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -2160,7 +2160,7 @@ unsafeSqlCase when v = ERaw Never buildCase
   where
     buildCase :: IdentInfo -> (TLB.Builder, [PersistValue])
     buildCase info =
-        let (elseText, elseVals) = valueToRawSqlParens v info
+        let (elseText, elseVals) = valueToRawSqlParens SqlCaseError v info
             (whenText, whenVals) = mapWhen when info
         in ( "CASE" <> whenText <> " ELSE " <> elseText <> " END", whenVals <> elseVals)
 
@@ -2172,8 +2172,8 @@ unsafeSqlCase when v = ERaw Never buildCase
     foldHelp _ _ (ECompositeKey _, _) = throw (CompositeKeyErr FoldHelpError)
     foldHelp _ _ (_, ECompositeKey _) = throw (CompositeKeyErr FoldHelpError)
     foldHelp info (b0, vals0) (v1, v2) =
-        let (b1, vals1) = valueToRawSqlParens v1 info
-            (b2, vals2) = valueToRawSqlParens v2 info
+        let (b1, vals1) = valueToRawSqlParens SqlCaseError v1 info
+            (b2, vals2) = valueToRawSqlParens SqlCaseError v2 info
         in ( b0 <> " WHEN " <> b1 <> " THEN " <> b2, vals0 <> vals1 <> vals2 )
 
 -- | (Internal) Convert a value to a raw SQL builder, preserving parens around
@@ -2181,11 +2181,11 @@ unsafeSqlCase when v = ERaw Never buildCase
 -- operator arguments.
 --
 -- Since: 3.4.0.2
-valueToRawSqlParens :: SqlExpr (Value a) -> IdentInfo -> (TLB.Builder, [PersistValue])
-valueToRawSqlParens (ERaw p f) = (first (parensM p)) . f
-valueToRawSqlParens (ECompositeKey _) = throw (CompositeKeyErr SqlCaseError)
-valueToRawSqlParens (EAliasedValue i _) = aliasedValueIdentToRawSql i
-valueToRawSqlParens (EValueReference i i') = valueReferenceToRawSql i i'
+valueToRawSqlParens :: UnexpectedValueError -> SqlExpr (Value a) -> IdentInfo -> (TLB.Builder, [PersistValue])
+valueToRawSqlParens _ (ERaw p f) = (first (parensM p)) . f
+valueToRawSqlParens e (ECompositeKey _) = throw (CompositeKeyErr e)
+valueToRawSqlParens _ (EAliasedValue i _) = aliasedValueIdentToRawSql i
+valueToRawSqlParens _ (EValueReference i i') = valueReferenceToRawSql i i'
 
 -- | (Internal) Create a custom binary operator.  You /should/
 -- /not/ use this function directly since its type is very
@@ -2329,7 +2329,7 @@ unsafeSqlFunctionParens
 unsafeSqlFunctionParens name arg =
     ERaw Never $ \info ->
         let (argsTLB, argsVals) =
-                uncommas' $ map (\v -> valueToRawSqlParens v info) $ toArgList arg
+                uncommas' $ map (\v -> valueToRawSqlParens SqlFunctionError v info) $ toArgList arg
         in
             (name <> parens argsTLB, argsVals)
 

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -91,7 +91,7 @@ unsafeSqlAggregateFunction name mode args orderByClauses = ERaw Never $ \info ->
                 [] -> ""
                 (_:_) -> " "
         (argsTLB, argsVals) =
-            uncommas' $ map (\(ERaw _ f) -> f info) $ toArgList args
+            uncommas' $ map (\v -> valueToRawSqlParens v info) $ toArgList args
         aggMode =
             case mode of
                 AggModeAll -> ""

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -91,7 +91,7 @@ unsafeSqlAggregateFunction name mode args orderByClauses = ERaw Never $ \info ->
                 [] -> ""
                 (_:_) -> " "
         (argsTLB, argsVals) =
-            uncommas' $ map (\v -> valueToRawSqlParens v info) $ toArgList args
+            uncommas' $ map (\v -> valueToRawSqlParens SqlFunctionError v info) $ toArgList args
         aggMode =
             case mode of
                 AggModeAll -> ""


### PR DESCRIPTION
Got the following error when using `unsafeSqlAggregateFunction`:
```
An exception has occurred: src/Database/Esqueleto/PostgreSQL.hs:94:30-50: Non-exhaustive patterns in lambda
```

This PR fixes the problem.

---

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).