### PR TITLE
Pass ConnectionPool to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ stack.yaml.lock
 .cabal-sandbox/
 cabal.sandbox.config
 .hspec-failures
+*.sqlite*
 cabal.project.freeze

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ test-ghcid:
 	ghcid -c "stack ghci --ghci-options -fobject-code esqueleto --test" \
 		--test "main" \
 		--warnings \
-		--restart "stack.yaml"
+		--restart "stack.yaml" \
+		--restart "esqueleto.cabal"
+
 
 
 init-pgsql:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,13 @@ test-ghci:
 
 test-ghcid:
 	ghcid -c "stack ghci --ghci-options -fobject-code esqueleto --test" \
-		--test "main" \
+		--warnings \
+		--restart "stack.yaml" \
+		--restart "esqueleto.cabal" \
+		--test main
+
+test-ghcid-build:
+	ghcid -c "stack ghci --ghci-options -fobject-code esqueleto --test" \
 		--warnings \
 		--restart "stack.yaml" \
 		--restart "esqueleto.cabal"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ test-ghci:
 	stack ghci esqueleto:test:sqlite
 
 test-ghcid:
-	ghcid -c "stack ghci --ghci-options -fobject-code esqueleto:test:sqlite"
+	ghcid -c "stack ghci --ghci-options -fobject-code esqueleto --test" \
+		--test "main" \
+		--warnings \
+		--restart "stack.yaml"
+
 
 init-pgsql:
 	sudo -u postgres -- createuser -s esqutest

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -100,7 +100,6 @@ test-suite specs
     build-depends:
         base >=4.8 && <5.0
       , aeson
-      , postgresql-simple
       , attoparsec
       , blaze-html
       , bytestring
@@ -116,8 +115,10 @@ test-suite specs
       , mysql-simple
       , persistent
       , persistent-mysql
-      , persistent-sqlite
       , persistent-postgresql
+      , persistent-sqlite
+      , postgresql-simple
+      , QuickCheck
       , resourcet 
       , tagged 
       , text 

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -77,7 +77,6 @@ library
         -Widentities
         -Wcpp-undef
         -Wcpp-undef
-        -Wmonomorphism-restriction
     default-language: Haskell2010
 
 test-suite specs

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1127,9 +1127,11 @@ testSelectDistinct :: SpecDb
 testSelectDistinct = do
   describe "SELECT DISTINCT" $ do
     let selDistTest
-          :: (   SqlQuery (SqlExpr (Value String))
-              -> SqlPersistT IO [Value String])
-          -> SqlPersistT IO Asserting
+          ::
+          ( SqlQuery (SqlExpr (Value String))
+              -> SqlPersistT IO [Value String]
+              )
+          -> SqlPersistT IO ()
         selDistTest q = do
           p1k <- insert p1
           let (t1, t2, t3) = ("a", "b", "c")
@@ -2321,8 +2323,8 @@ insert' v = flip Entity v <$> insert v
 -- thus must be cleaned after each test.
 -- TODO: there is certainly a better way...
 cleanDB
-  :: (forall m. RunDbMonad m
-  => SqlPersistT (R.ResourceT m) ())
+    :: forall m. _
+    => SqlPersistT m ()
 cleanDB = do
   delete $ from $ \(_ :: SqlExpr (Entity Bar))  -> return ()
   delete $ from $ \(_ :: SqlExpr (Entity Foo))  -> return ()
@@ -2361,10 +2363,10 @@ cleanDB = do
 
 
 cleanUniques
-  :: (forall m. RunDbMonad m
-  => SqlPersistT (R.ResourceT m) ())
+    :: forall m. MonadIO m
+    => SqlPersistT m ()
 cleanUniques =
-  delete $ from $ \(_ :: SqlExpr (Entity OneUnique))    -> return ()
+    delete $ from $ \(_ :: SqlExpr (Entity OneUnique))    -> return ()
 
 selectRethrowingQuery
   :: (MonadIO m, EI.SqlSelect a r, MonadUnliftIO m)

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -68,7 +69,7 @@ import Common.Test.Import hiding (from, on)
 
 import Control.Monad (forM_, replicateM, replicateM_, void)
 import Control.Monad.Catch (MonadCatch)
-import Control.Monad.Reader (ask)
+import Control.Monad.Reader (ask, mapReaderT)
 import Data.Either
 import Data.Time
 #if __GLASGOW_HASKELL__ >= 806
@@ -88,7 +89,7 @@ import Database.Persist.TH
 import Test.Hspec
 import UnliftIO
 
-import Data.Conduit (ConduitT, runConduit, (.|))
+import Data.Conduit (ConduitT, runConduit, (.|), runConduitRes)
 import qualified Data.Conduit.List as CL
 import qualified Data.List as L
 import qualified Data.Set as S
@@ -150,8 +151,8 @@ u3 = OneUnique "Third" 0
 u4 :: OneUnique
 u4 = OneUnique "First" 2
 
-testSubSelect :: Run -> Spec
-testSubSelect run = do
+testSubSelect :: SpecDb
+testSubSelect = do
     let setup :: MonadIO m => SqlPersistT m ()
         setup = do
             _ <- insert $ Numbers 1 2
@@ -161,55 +162,55 @@ testSubSelect run = do
             pure ()
 
     describe "subSelect" $ do
-        it "is safe for queries that may return multiple results" $ do
+        itDb "is safe for queries that may return multiple results" $ do
             let query =
                   from $ \n -> do
                   orderBy [asc (n ^. NumbersInt)]
                   pure (n ^. NumbersInt)
-            res <- run $ do
-                setup
-                select $ pure $ subSelect query
-            res `shouldBe` [Value (Just 1)]
-
-            eres <- try $ run $ do
+            setup
+            res <- select $ pure $ subSelect query
+            eres <- try $ do
                 setup
                 select $ pure $ sub_select query
-            case eres of
-                Left (SomeException _) ->
-                    -- We should receive an exception, but the different database
-                    -- libraries throw different exceptions. Hooray.
-                    pure ()
-                Right v ->
-                    -- This shouldn't happen, but in sqlite land, many things are
-                    -- possible.
-                    v `shouldBe` [Value 1]
+            asserting $ do
+                res `shouldBe` [Value (Just 1)]
+                case eres of
+                    Left (SomeException _) ->
+                        -- We should receive an exception, but the different database
+                        -- libraries throw different exceptions. Hooray.
+                        pure ()
+                    Right v ->
+                        -- This shouldn't happen, but in sqlite land, many things are
+                        -- possible.
+                        v `shouldBe` [Value 1]
 
-        it "is safe for queries that may not return anything" $ do
+        itDb "is safe for queries that may not return anything" $ do
             let query =
                     from $ \n -> do
                     orderBy [asc (n ^. NumbersInt)]
                     limit 1
                     pure (n ^. NumbersInt)
-            res <- run $ select $ pure $ subSelect query
-            res `shouldBe` [Value Nothing]
+            setup
+            res <- select $ pure $ subSelect query
 
-            eres <- try $ run $ do
-                setup
+            eres <- try $ do
                 select $ pure $ sub_select query
 
-            case eres of
-                Left (_ :: PersistException) ->
-                    -- We expect to receive this exception. However, sqlite evidently has
-                    -- no problems with it, so we can't *require* that the exception is
-                    -- thrown. Sigh.
-                    pure ()
-                Right v ->
-                    -- This shouldn't happen, but in sqlite land, many things are
-                    -- possible.
-                    v `shouldBe` [Value 1]
+            asserting $ do
+                res `shouldBe` [Value Nothing]
+                case eres of
+                    Left (_ :: PersistException) ->
+                        -- We expect to receive this exception. However, sqlite evidently has
+                        -- no problems with itDb, so we can't *require* that the exception is
+                        -- thrown. Sigh.
+                        pure ()
+                    Right v ->
+                        -- This shouldn't happen, but in sqlite land, many things are
+                        -- possible.
+                        v `shouldBe` [Value 1]
 
     describe "subSelectList" $ do
-        it "is safe on empty databases as well as good databases" $ run $ do
+        itDb "is safe on empty databases as well as good databases" $ do
             let query =
                     from $ \n -> do
                     where_ $ n ^. NumbersInt `in_` do
@@ -224,12 +225,12 @@ testSubSelect run = do
                 setup
                 select query
 
-            liftIO $ do
+            asserting $ do
                 empty `shouldBe` []
                 full `shouldSatisfy` (not . null)
 
     describe "subSelectMaybe" $ do
-        it "is equivalent to joinV . subSelect" $ do
+        itDb "is equivalent to joinV . subSelect" $ do
             let query
                     :: (SqlQuery (SqlExpr (Value (Maybe Int))) -> SqlExpr (Value (Maybe Int)))
                     -> SqlQuery (SqlExpr (Value (Maybe Int)))
@@ -241,18 +242,15 @@ testSubSelect run = do
                         where_ $ n' ^. NumbersDouble >=. n ^. NumbersDouble
                         pure (max_ (n' ^. NumbersInt))
 
-            a <- run $ do
-                setup
-                select (query subSelectMaybe)
-            b <- run $ do
-                setup
-                select (query (joinV . subSelect))
-            a `shouldBe` b
+            setup
+            a <- select (query subSelectMaybe)
+            b <- select (query (joinV . subSelect))
+            asserting $ a `shouldBe` b
 
     describe "subSelectCount" $ do
-        it "is a safe way to do a countRows" $ do
-            xs0 <- run $ do
-                setup
+        itDb "is a safe way to do a countRows" $ do
+            setup
+            xs0 <-
                 select $
                     from $ \n -> do
                     pure $ (,) n $
@@ -260,8 +258,7 @@ testSubSelect run = do
                         from $ \n' -> do
                         where_ $ n' ^. NumbersInt >=. n ^. NumbersInt
 
-            xs1 <- run $ do
-                setup
+            xs1 <-
                 select $
                     from $ \n -> do
                     pure $ (,) n $
@@ -271,12 +268,13 @@ testSubSelect run = do
                         pure (countRows :: SqlExpr (Value Int))
 
             let getter (Entity _ a, b) = (a, b)
-            map getter xs0 `shouldBe` map getter xs1
+            asserting $
+                map getter xs0 `shouldBe` map getter xs1
 
     describe "subSelectUnsafe" $ do
-        it "throws exceptions on multiple results" $ do
-            eres <- try $ run $ do
-                setup
+        itDb "throws exceptions on multiple results" $ do
+            setup
+            eres <- try $ do
                 bad <- select $
                     from $ \n -> do
                     pure $ (,) (n ^. NumbersInt) $
@@ -290,19 +288,18 @@ testSubSelect run = do
                         from $ \n' -> do
                         pure (n' ^. NumbersDouble)
                 pure (bad, good)
-            case eres of
+            asserting $ case eres of
                 Left (SomeException _) ->
                     -- Must use SomeException because the database libraries throw their
                     -- own errors.
                     pure ()
                 Right (bad, good) -> do
                     -- SQLite just takes the first element of the sub-select. lol.
-                    --
                     bad `shouldBe` good
 
-        it "throws exceptions on null results" $ do
-            eres <- try $ run $ do
-                setup
+        itDb "throws exceptions on null results" $ do
+            setup
+            eres <- try $ do
                 select $
                     from $ \n -> do
                     pure $ (,) (n ^. NumbersInt) $
@@ -310,34 +307,35 @@ testSubSelect run = do
                         from $ \n' -> do
                         where_ $ val False
                         pure (n' ^. NumbersDouble)
-            case eres of
+            asserting $ case eres of
                 Left (_ :: PersistException) ->
                     pure ()
                 Right xs ->
                     xs `shouldBe` []
 
-testSelectSource :: Run -> Spec
-testSelectSource run = do
+testSelectSource :: SpecDb
+testSelectSource = do
     describe "selectSource" $ do
-        it "works for a simple example" $ run $ do
+        itDb "works for a simple example" $ do
             let query = selectSource $
                         from $ \person ->
                         return person
             p1e <- insert' p1
-            ret <- runConduit $ query .| CL.consume
-            liftIO $ ret `shouldBe` [ p1e ]
+            ret <- mapReaderT R.runResourceT $ runConduit $ query .| CL.consume
+            asserting $ ret `shouldBe` [ p1e ]
 
-        it "can run a query many times" $ run $ do
+        itDb "can run a query many times" $ do
             let query = selectSource $
                         from $ \person ->
                         return person
             p1e <- insert' p1
-            ret0 <- runConduit $ query .| CL.consume
-            ret1 <- runConduit $ query .| CL.consume
-            liftIO $ ret0 `shouldBe` [ p1e ]
-            liftIO $ ret1 `shouldBe` [ p1e ]
+            ret0 <- mapReaderT R.runResourceT $ runConduit $ query .| CL.consume
+            ret1 <- mapReaderT R.runResourceT $ runConduit $ query .| CL.consume
+            asserting $ do
+                ret0 `shouldBe` [ p1e ]
+                ret1 `shouldBe` [ p1e ]
 
-        it "works on repro" $ do
+        itDb "works on repro" $ do
             let selectPerson :: R.MonadResource m => String -> ConduitT () (Key Person) (SqlPersistT m) ()
                 selectPerson name = do
                     let source =
@@ -345,42 +343,41 @@ testSelectSource run = do
                             where_ $ person ^. PersonName ==. val name
                             return $ person ^. PersonId
                     source .| CL.map unValue
-            run $ do
-                p1e <- insert' p1
-                p2e <- insert' p2
-                r1 <- runConduit $ selectPerson (personName p1) .| CL.consume
-                r2 <- runConduit $ selectPerson (personName p2) .| CL.consume
-                liftIO $ do
-                  r1 `shouldBe` [ entityKey p1e ]
-                  r2 `shouldBe` [ entityKey p2e ]
+            p1e <- insert' p1
+            p2e <- insert' p2
+            r1 <- mapReaderT R.runResourceT $ runConduit $ selectPerson (personName p1) .| CL.consume
+            r2 <- mapReaderT R.runResourceT $ runConduit $ selectPerson (personName p2) .| CL.consume
+            asserting $ do
+                r1 `shouldBe` [ entityKey p1e ]
+                r2 `shouldBe` [ entityKey p2e ]
 
-testSelectFrom :: Run -> Spec
-testSelectFrom run = do
+testSelectFrom :: SpecDb
+testSelectFrom = do
     describe "select/from" $ do
-        it "works for a simple example" $ run $ do
+        itDb "works for a simple example" $ do
             p1e <- insert' p1
             ret <-
                 select $
                 from $ \person ->
                 return person
-            liftIO $ ret `shouldBe` [ p1e ]
+            asserting $ ret `shouldBe` [ p1e ]
 
-        it "works for a simple self-join (one entity)" $ run $ do
+        itDb "works for a simple self-join (one entity)" $ do
             p1e <- insert' p1
             ret <-
                 select $
                 from $ \(person1, person2) ->
                 return (person1, person2)
-            liftIO $ ret `shouldBe` [ (p1e, p1e) ]
+            asserting $ ret `shouldBe` [ (p1e, p1e) ]
 
-        it "works for a simple self-join (two entities)" $ run $ do
+        itDb "works for a simple self-join (two entities)" $ do
             p1e <- insert' p1
             p2e <- insert' p2
             ret <-
                 select $
                 from $ \(person1, person2) ->
                 return (person1, person2)
-            liftIO $
+            asserting $
                 ret
                     `shouldSatisfy`
                         sameElementsAs
@@ -390,7 +387,7 @@ testSelectFrom run = do
                             , (p2e, p2e)
                             ]
 
-        it "works for a self-join via sub_select" $ run $ do
+        itDb "works for a self-join via sub_select" $ do
             p1k <- insert p1
             p2k <- insert p2
             _f1k <- insert (Follow p1k p2k)
@@ -403,9 +400,9 @@ testSelectFrom run = do
                          return $ followB ^. FollowFollower
                    where_ $ followA ^. FollowFollowed ==. sub_select subquery
                    return followA
-            liftIO $ length ret `shouldBe` 2
+            asserting $ length ret `shouldBe` 2
 
-        it "works for a self-join via exists" $ run $ do
+        itDb "works for a self-join via exists" $ do
             p1k <- insert p1
             p2k <- insert p2
             _f1k <- insert (Follow p1k p2k)
@@ -416,31 +413,31 @@ testSelectFrom run = do
                             from $ \followB ->
                             where_ $ followA ^. FollowFollower ==. followB ^. FollowFollowed
                    return followA
-            liftIO $ length ret `shouldBe` 2
+            asserting $ length ret `shouldBe` 2
 
 
-        it "works for a simple projection" $ run $ do
+        itDb "works for a simple projection" $ do
             p1k <- insert p1
             p2k <- insert p2
             ret <- select $
                    from $ \p ->
                    return (p ^. PersonId, p ^. PersonName)
-            liftIO $ ret `shouldBe` [ (Value p1k, Value (personName p1))
+            asserting $ ret `shouldBe` [ (Value p1k, Value (personName p1))
                                     , (Value p2k, Value (personName p2)) ]
 
-        it "works for a simple projection with a simple implicit self-join" $ run $ do
+        itDb "works for a simple projection with a simple implicit self-join" $ do
             _ <- insert p1
             _ <- insert p2
             ret <- select $
                    from $ \(pa, pb) ->
                    return (pa ^. PersonName, pb ^. PersonName)
-            liftIO $ ret `shouldSatisfy` sameElementsAs
+            asserting $ ret `shouldSatisfy` sameElementsAs
                                     [ (Value (personName p1), Value (personName p1))
                                     , (Value (personName p1), Value (personName p2))
                                     , (Value (personName p2), Value (personName p1))
                                     , (Value (personName p2), Value (personName p2)) ]
 
-        it "works with many kinds of LIMITs and OFFSETs" $ run $ do
+        itDb "works with many kinds of LIMITs and OFFSETs" $ do
             [p1e, p2e, p3e, p4e] <- mapM insert' [p1, p2, p3, p4]
             let people =
                     from $ \p -> do
@@ -452,21 +449,21 @@ testSelectFrom run = do
                 limit 2
                 limit 1
                 return p
-            liftIO $ ret1 `shouldBe` [ p1e ]
+            asserting $ ret1 `shouldBe` [ p1e ]
             ret2 <-
                 select $ do
                 p <- people
                 limit 1
                 limit 2
                 return p
-            liftIO $ ret2 `shouldBe` [ p1e, p4e ]
+            asserting $ ret2 `shouldBe` [ p1e, p4e ]
             ret3 <-
                 select $ do
                 p <- people
                 offset 3
                 offset 2
                 return p
-            liftIO $ ret3 `shouldBe` [ p3e, p2e ]
+            asserting $ ret3 `shouldBe` [ p3e, p2e ]
             ret4 <-
                 select $ do
                 p <- people
@@ -477,7 +474,7 @@ testSelectFrom run = do
                 offset 1
                 limit 2
                 return p
-            liftIO $ ret4 `shouldBe` [ p4e, p3e ]
+            asserting $ ret4 `shouldBe` [ p4e, p3e ]
             ret5 <-
                 select $ do
                 p <- people
@@ -486,39 +483,39 @@ testSelectFrom run = do
                 limit  1000
                 offset 0
                 return p
-            liftIO $ ret5 `shouldBe` [ p1e, p4e, p3e, p2e ]
+            asserting $ ret5 `shouldBe` [ p1e, p4e, p3e, p2e ]
 
-        it "works with non-id primary key" $ run $ do
+        itDb "works with non-id primary key" $ do
             let fc = Frontcover number ""
                 number = 101
                 Right thePk = keyFromValues [toPersistValue number]
             fcPk <- insert fc
             [Entity _ ret] <- select $ from return
-            liftIO $ do
+            asserting $ do
                 ret `shouldBe` fc
                 fcPk `shouldBe` thePk
 
-        it "works when returning a custom non-composite primary key from a query" $ run $ do
+        itDb "works when returning a custom non-composite primary key from a query" $ do
             let name = "foo"
                 t = Tag name
                 Right thePk = keyFromValues [toPersistValue name]
             tagPk <- insert t
             [Value ret] <- select $ from $ \t' -> return (t'^.TagId)
-            liftIO $ do
+            asserting $ do
                 ret `shouldBe` thePk
                 thePk `shouldBe` tagPk
 
-        it "works when returning a composite primary key from a query" $ run $ do
+        itDb "works when returning a composite primary key from a query" $ do
             let p = Point 10 20 ""
             thePk <- insert p
             [Value ppk] <- select $ from $ \p' -> return (p'^.PointId)
-            liftIO $ ppk `shouldBe` thePk
+            asserting $ ppk `shouldBe` thePk
 
-testSelectJoin :: Run -> Spec
-testSelectJoin run = do
+testSelectJoin :: SpecDb
+testSelectJoin = do
   describe "select:JOIN" $ do
-    it "works with a LEFT OUTER JOIN" $
-      run $ do
+    itDb "works with a LEFT OUTER JOIN" $
+      do
         p1e <- insert' p1
         p2e <- insert' p2
         p3e <- insert' p3
@@ -531,47 +528,50 @@ testSelectJoin run = do
                on (just (p ^. PersonId) ==. mb ?. BlogPostAuthorId)
                orderBy [ asc (p ^. PersonName), asc (mb ?. BlogPostTitle) ]
                return (p, mb)
-        liftIO $ ret `shouldBe` [ (p1e, Just b11e)
+        asserting $ ret `shouldBe` [ (p1e, Just b11e)
                                 , (p1e, Just b12e)
                                 , (p4e, Nothing)
                                 , (p3e, Just b31e)
                                 , (p2e, Nothing) ]
 
-    it "typechecks (A LEFT OUTER JOIN (B LEFT OUTER JOIN C))" $
-      let _ = run $
-              select $
-              from $ \(a `LeftOuterJoin` (b `LeftOuterJoin` c)) ->
-              let _ = [a, b, c] :: [ SqlExpr (Entity Person) ]
-              in return a
-      in return () :: IO ()
+    itDb "typechecks (A LEFT OUTER JOIN (B LEFT OUTER JOIN C))" $
+        let
+            _x :: SqlPersistT IO _
+            _x =
+                select $
+                from $ \(a `LeftOuterJoin` (b `LeftOuterJoin` c)) ->
+                let _ = [a, b, c] :: [ SqlExpr (Entity Person) ]
+                in return a
+      in asserting noExceptions
 
-    it "typechecks ((A LEFT OUTER JOIN B) LEFT OUTER JOIN C)" $
-      let _ = run $
-              select $
-              from $ \((a `LeftOuterJoin` b) `LeftOuterJoin` c) ->
-              let _ = [a, b, c] :: [ SqlExpr (Entity Person) ]
-              in return a
-      in return () :: IO ()
+    itDb "typechecks ((A LEFT OUTER JOIN B) LEFT OUTER JOIN C)" $
+        let _x :: SqlPersistT IO _
+            _x =
+                select $
+                from $ \((a `LeftOuterJoin` b) `LeftOuterJoin` c) ->
+                let _ = [a, b, c] :: [ SqlExpr (Entity Person) ]
+                in return a
+        in asserting noExceptions
 
-    it "throws an error for using on without joins" $
-      run (select $
-           from $ \(p, mb) -> do
+    itDb "throws an error for using on without joins" $ do
+      eres <- try $ select $
+            from $ \(p, mb) -> do
            on (just (p ^. PersonId) ==. mb ?. BlogPostAuthorId)
            orderBy [ asc (p ^. PersonName), asc (mb ?. BlogPostTitle) ]
            return (p, mb)
-      ) `shouldThrow` (\(OnClauseWithoutMatchingJoinException _) -> True)
+      asserting $ shouldBeOnClauseWithoutMatchingJoinException eres
 
-    it "throws an error for using too many ons" $
-      run (select $
+    itDb "throws an error for using too many ons" $ do
+      eres <- try $ select $
            from $ \(p `FullOuterJoin` mb) -> do
            on (just (p ^. PersonId) ==. mb ?. BlogPostAuthorId)
            on (just (p ^. PersonId) ==. mb ?. BlogPostAuthorId)
            orderBy [ asc (p ^. PersonName), asc (mb ?. BlogPostTitle) ]
            return (p, mb)
-      ) `shouldThrow` (\(OnClauseWithoutMatchingJoinException _) -> True)
+      asserting $ shouldBeOnClauseWithoutMatchingJoinException eres
 
-    it "works with ForeignKey to a non-id primary key returning one entity" $
-      run $ do
+    itDb "works with ForeignKey to a non-id primary key returning one entity" $
+      do
         let fc = Frontcover number ""
             article = Article "Esqueleto supports composite pks!" number
             number = 101
@@ -582,11 +582,11 @@ testSelectJoin run = do
           from $ \(a `InnerJoin` f) -> do
             on (f^.FrontcoverNumber ==. a^.ArticleFrontcoverNumber)
             return f
-        liftIO $ do
+        asserting $ do
           retFc `shouldBe` fc
           fcPk `shouldBe` thePk
-    it "allows using a primary key that is itself a key of another table" $
-      run $ do
+    itDb "allows using a primary key that is itself a key of another table" $
+      do
         let number = 101
         insert_ $ Frontcover number ""
         articleId <- insert $ Article "title" number
@@ -594,9 +594,9 @@ testSelectJoin run = do
         result <- select $ from $ \articleMetadata -> do
           where_ $ (articleMetadata ^. ArticleMetadataId) ==. (val ((ArticleMetadataKey articleId)))
           pure articleMetadata
-        liftIO $ [articleMetaE] `shouldBe` result
-    it "allows joining between a primary key that is itself a key of another table, using ToBaseId" $ do
-      run $ do
+        asserting $ [articleMetaE] `shouldBe` result
+    itDb "allows joining between a primary key that is itself a key of another table, using ToBaseId" $ do
+      do
         let number = 101
         insert_ $ Frontcover number ""
         articleE@(Entity articleId _) <- insert' $ Article "title" number
@@ -606,10 +606,10 @@ testSelectJoin run = do
           from $ \(article `InnerJoin` articleMetadata) -> do
           on (toBaseId (articleMetadata ^. ArticleMetadataId) ==. article ^. ArticleId)
           return (article, articleMetadata)
-        liftIO $ [(articleE, articleMetaE)] `shouldBe` articlesAndMetadata
+        asserting $ [(articleE, articleMetaE)] `shouldBe` articlesAndMetadata
 
-    it "works with a ForeignKey to a non-id primary key returning both entities" $
-      run $ do
+    itDb "works with a ForeignKey to a non-id primary key returning both entities" $
+      do
         let fc = Frontcover number ""
             article = Article "Esqueleto supports composite pks!" number
             number = 101
@@ -620,14 +620,14 @@ testSelectJoin run = do
           from $ \(a `InnerJoin` f) -> do
             on (f^.FrontcoverNumber ==. a^.ArticleFrontcoverNumber)
             return (f, a)
-        liftIO $ do
+        asserting $ do
           retFc `shouldBe` fc
           retArt `shouldBe` article
           fcPk `shouldBe` thePk
           articleFkfrontcover retArt `shouldBe` thePk
 
-    it "works with a non-id primary key returning one entity" $
-      run $ do
+    itDb "works with a non-id primary key returning one entity" $
+      do
         let fc = Frontcover number ""
             article = Article2 "Esqueleto supports composite pks!" thePk
             number = 101
@@ -638,14 +638,14 @@ testSelectJoin run = do
           from $ \(a `InnerJoin` f) -> do
             on (f^.FrontcoverId ==. a^.Article2FrontcoverId)
             return f
-        liftIO $ do
+        asserting $ do
           retFc `shouldBe` fc
           fcPk `shouldBe` thePk
 
-    it "works with a composite primary key" $
+    it "works with a composite primary key" $ \_ ->
       pendingWith "Persistent does not create the CircleFkPoint constructor. See: https://github.com/yesodweb/persistent/issues/341"
       {-
-      run $ do
+      do
         let p = Point x y ""
             c = Circle x y ""
             x = 10
@@ -656,13 +656,13 @@ testSelectJoin run = do
         [Entity _ ret] <- select $ from $ \(c' `InnerJoin` p') -> do
           on (p'^.PointId ==. c'^.CircleFkpoint)
           return p'
-        liftIO $ do
+        asserting $ do
           ret `shouldBe` p
           pPk `shouldBe` thePk
      -}
 
-    it "works when joining via a non-id primary key" $
-      run $ do
+    itDb "works when joining via a non-id primary key" $
+      do
         let fc = Frontcover number ""
             article = Article "Esqueleto supports composite pks!" number
             tag = Tag "foo"
@@ -678,12 +678,12 @@ testSelectJoin run = do
             on (t^.TagId ==. at^.ArticleTagTagId)
             on (a^.ArticleId ==. at^.ArticleTagArticleId)
             return (a, t)
-        liftIO $ do
+        asserting $ do
           retArt `shouldBe` article
           retTag `shouldBe` tag
 
-    it "respects the associativity of joins" $
-      run $ do
+    itDb "respects the associativity of joins" $
+      do
           void $ insert p1
           ps <- select $ from $
                     \((p :: SqlExpr (Entity Person))
@@ -693,19 +693,19 @@ testSelectJoin run = do
               on (val False) -- Inner join is empty
               on (val True)
               return p
-          liftIO $ (entityVal <$> ps) `shouldBe` [p1]
+          asserting $ (entityVal <$> ps) `shouldBe` [p1]
 
-testSelectSubQuery :: Run -> Spec
-testSelectSubQuery run = describe "select subquery" $ do
-    it "works" $ run $ do
+testSelectSubQuery :: SpecDb
+testSelectSubQuery = describe "select subquery" $ do
+    itDb "works" $ do
         _ <- insert' p1
         let q = do
                 p <- Experimental.from $ Table @Person
                 return ( p ^. PersonName, p ^. PersonAge)
         ret <- select $ Experimental.from q
-        liftIO $ ret `shouldBe` [ (Value $ personName p1, Value $ personAge p1) ]
+        asserting $ ret `shouldBe` [ (Value $ personName p1, Value $ personAge p1) ]
 
-    it "supports sub-selecting Maybe entities" $ run $ do
+    itDb "supports sub-selecting Maybe entities" $ do
         l1e <- insert' l1
         l3e <- insert' l3
         l1Deeds <- mapM (\k -> insert' $ Deed k (entityKey l1e)) (map show [1..3 :: Int])
@@ -719,9 +719,9 @@ testSelectSubQuery run = describe "select subquery" $ do
                   pure (lords, deeds)
 
         ret <- select q
-        liftIO $ ret `shouldMatchList` ((l3e, Nothing) : l1WithDeeds)
+        asserting $ ret `shouldMatchList` ((l3e, Nothing) : l1WithDeeds)
 
-    it "lets you order by alias" $ run $ do
+    itDb "lets you order by alias" $ do
         _ <- insert' p1
         _ <- insert' p3
         let q = do
@@ -732,9 +732,9 @@ testSelectSubQuery run = describe "select subquery" $ do
                 orderBy [ asc age ]
                 pure name
         ret <- select q
-        liftIO $ ret `shouldBe` [ Value $ personName p3, Value $ personName p1 ]
+        asserting $ ret `shouldBe` [ Value $ personName p3, Value $ personName p1 ]
 
-    it "supports groupBy" $ run $ do
+    itDb "supports groupBy" $ do
         l1k <- insert l1
         l3k <- insert l3
         mapM_ (\k -> insert $ Deed k l1k) (map show [1..3 :: Int])
@@ -752,10 +752,10 @@ testSelectSubQuery run = describe "select subquery" $ do
                  return (lordId, count deedId)
         (ret :: [(Value (Key Lord), Value Int)]) <- select q'
 
-        liftIO $ ret `shouldMatchList` [ (Value l3k, Value 7)
+        asserting $ ret `shouldMatchList` [ (Value l3k, Value 7)
                                        , (Value l1k, Value 3) ]
 
-    it "Can count results of aggregate query" $ run $ do
+    itDb "Can count results of aggregate query" $ do
         l1k <- insert l1
         l3k <- insert l3
         mapM_ (\k -> insert $ Deed k l1k) (map show [1..3 :: Int])
@@ -774,9 +774,9 @@ testSelectSubQuery run = describe "select subquery" $ do
                  where_ $ deedCount >. val (3 :: Int)
                  return (count lordId)
 
-        liftIO $ ret `shouldMatchList` [ (Value 1) ]
+        asserting $ ret `shouldMatchList` [ (Value 1) ]
 
-    it "joins on subqueries" $ run $ do
+    itDb "joins on subqueries" $ do
         l1k <- insert l1
         l3k <- insert l3
         mapM_ (\k -> insert $ Deed k l1k) (map show [1..3 :: Int])
@@ -790,10 +790,10 @@ testSelectSubQuery run = describe "select subquery" $ do
                 groupBy (lord ^. LordId)
                 return (lord ^. LordId, count (deed ^. DeedId))
         (ret :: [(Value (Key Lord), Value Int)]) <- select q
-        liftIO $ ret `shouldMatchList` [ (Value l3k, Value 7)
+        asserting $ ret `shouldMatchList` [ (Value l3k, Value 7)
                                        , (Value l1k, Value 3) ]
 
-    it "flattens maybe values" $ run $ do
+    itDb "flattens maybe values" $ do
         l1k <- insert l1
         l3k <- insert l3
         let q = do
@@ -806,9 +806,9 @@ testSelectSubQuery run = describe "select subquery" $ do
                 groupBy (lord ^. LordId, dogCounts)
                 return (lord ^. LordId, dogCounts)
         (ret :: [(Value (Key Lord), Value (Maybe Int))]) <- select q
-        liftIO $ ret `shouldMatchList` [ (Value l3k, Value (lordDogs l3))
+        asserting $ ret `shouldMatchList` [ (Value l3k, Value (lordDogs l3))
                                        , (Value l1k, Value (lordDogs l1)) ]
-    it "unions" $ run $ do
+    itDb "unions" $ do
           _ <- insert p1
           _ <- insert p2
           let q = Experimental.from $
@@ -827,11 +827,11 @@ testSelectSubQuery run = describe "select subquery" $ do
                     where_ $ isNothing $ p ^. PersonAge
                     return (p ^. PersonName))
           names <- select q
-          liftIO $ names `shouldMatchList` [ (Value $ personName p1)
+          asserting $ names `shouldMatchList` [ (Value $ personName p1)
                                            , (Value $ personName p2) ]
-testSelectWhere :: Run -> Spec
-testSelectWhere run = describe "select where_" $ do
-    it "works for a simple example with (==.)" $ run $ do
+testSelectWhere :: SpecDb
+testSelectWhere = describe "select where_" $ do
+    itDb "works for a simple example with (==.)" $ do
         p1e <- insert' p1
         _   <- insert' p2
         _   <- insert' p3
@@ -839,9 +839,9 @@ testSelectWhere run = describe "select where_" $ do
                from $ \p -> do
                where_ (p ^. PersonName ==. val "John")
                return p
-        liftIO $ ret `shouldBe` [ p1e ]
+        asserting $ ret `shouldBe` [ p1e ]
 
-    it "works for a simple example with (==.) and (||.)" $ run $ do
+    itDb "works for a simple example with (==.) and (||.)" $ do
         p1e <- insert' p1
         p2e <- insert' p2
         _   <- insert' p3
@@ -849,9 +849,9 @@ testSelectWhere run = describe "select where_" $ do
                from $ \p -> do
                where_ (p ^. PersonName ==. val "John" ||. p ^. PersonName ==. val "Rachel")
                return p
-        liftIO $ ret `shouldBe` [ p1e, p2e ]
+        asserting $ ret `shouldBe` [ p1e, p2e ]
 
-    it "works for a simple example with (>.) [uses val . Just]" $ run $ do
+    itDb "works for a simple example with (>.) [uses val . Just]" $ do
         p1e <- insert' p1
         _   <- insert' p2
         _   <- insert' p3
@@ -859,9 +859,9 @@ testSelectWhere run = describe "select where_" $ do
                from $ \p -> do
                where_ (p ^. PersonAge >. val (Just 17))
                return p
-        liftIO $ ret `shouldBe` [ p1e ]
+        asserting $ ret `shouldBe` [ p1e ]
 
-    it "works for a simple example with (>.) and not_ [uses just . val]" $ run $ do
+    itDb "works for a simple example with (>.) and not_ [uses just . val]" $ do
         _   <- insert' p1
         _   <- insert' p2
         p3e <- insert' p3
@@ -869,10 +869,10 @@ testSelectWhere run = describe "select where_" $ do
                from $ \p -> do
                where_ (not_ $ p ^. PersonAge >. just (val 17))
                return p
-        liftIO $ ret `shouldBe` [ p3e ]
+        asserting $ ret `shouldBe` [ p3e ]
 
     describe "when using between" $ do
-        it "works for a simple example with [uses just . val]" $ run $ do
+        itDb "works for a simple example with [uses just . val]" $ do
             p1e  <- insert' p1
             _    <- insert' p2
             _    <- insert' p3
@@ -880,8 +880,8 @@ testSelectWhere run = describe "select where_" $ do
               from $ \p -> do
                 where_ ((p ^. PersonAge) `between` (just $ val 20, just $ val 40))
                 return p
-            liftIO $ ret `shouldBe` [ p1e ]
-        it "works for a proyected fields value" $ run $ do
+            asserting $ ret `shouldBe` [ p1e ]
+        itDb "works for a proyected fields value" $ do
             _ <- insert' p1 >> insert' p2 >> insert' p3
             ret <-
               select $
@@ -890,9 +890,9 @@ testSelectWhere run = describe "select where_" $ do
                 just (p ^. PersonFavNum)
                   `between`
                     (p ^. PersonAge, p ^.  PersonWeight)
-            liftIO $ ret `shouldBe` []
+            asserting $ ret `shouldBe` []
         describe "when projecting composite keys" $ do
-            it "works when using composite keys with val" $ run $ do
+            itDb "works when using composite keys with val" $ do
                 insert_ $ Point 1 2 ""
                 ret <-
                   select $
@@ -902,9 +902,9 @@ testSelectWhere run = describe "select where_" $ do
                       `between`
                         ( val $ PointKey 1 2
                         , val $ PointKey 5 6 )
-                liftIO $ ret `shouldBe` [()]
+                asserting $ ret `shouldBe` [()]
 
-    it "works with avg_" $ run $ do
+    itDb "works with avg_" $ do
         _ <- insert' p1
         _ <- insert' p2
         _ <- insert' p3
@@ -917,10 +917,10 @@ testSelectWhere run = describe "select where_" $ do
 
             retV :: [Value (Maybe Double)]
             retV = map (Value . fmap (roundTo (4 :: Integer)) . unValue) (ret :: [Value (Maybe Double)])
-        liftIO $ retV `shouldBe` [ Value $ Just testV ]
+        asserting $ retV `shouldBe` [ Value $ Just testV ]
 
-    it "works with min_" $
-      run $ do
+    itDb "works with min_" $
+      do
         _ <- insert' p1
         _ <- insert' p2
         _ <- insert' p3
@@ -928,9 +928,9 @@ testSelectWhere run = describe "select where_" $ do
         ret <- select $
                from $ \p->
                return $ joinV $ min_ (p ^. PersonAge)
-        liftIO $ ret `shouldBe` [ Value $ Just (17 :: Int) ]
+        asserting $ ret `shouldBe` [ Value $ Just (17 :: Int) ]
 
-    it "works with max_" $ run $ do
+    itDb "works with max_" $ do
         _ <- insert' p1
         _ <- insert' p2
         _ <- insert' p3
@@ -938,9 +938,9 @@ testSelectWhere run = describe "select where_" $ do
         ret <- select $
                from $ \p->
                return $ joinV $ max_ (p ^. PersonAge)
-        liftIO $ ret `shouldBe` [ Value $ Just (36 :: Int) ]
+        asserting $ ret `shouldBe` [ Value $ Just (36 :: Int) ]
 
-    it "works with lower_" $ run $ do
+    itDb "works with lower_" $ do
         p1e <- insert' p1
         p2e@(Entity _ bob) <- insert' $ Person "bob" (Just 36) Nothing   1
 
@@ -949,20 +949,20 @@ testSelectWhere run = describe "select where_" $ do
                 from $ \p-> do
                 where_ (lower_ (p ^. PersonName) ==. val (map toLower $ personName p1))
                 return p
-        liftIO $ ret1 `shouldBe` [ p1e ]
+        asserting $ ret1 `shouldBe` [ p1e ]
 
         -- name == lower('BOB')
         ret2 <- select $
                 from $ \p-> do
                 where_ (p ^. PersonName ==. lower_ (val $ map toUpper $ personName bob))
                 return p
-        liftIO $ ret2 `shouldBe` [ p2e ]
+        asserting $ ret2 `shouldBe` [ p2e ]
 
-    it "works with round_" $ run $ do
+    itDb "works with round_" $ do
         ret <- select $ return $ round_ (val (16.2 :: Double))
-        liftIO $ ret `shouldBe` [ Value (16 :: Double) ]
+        asserting $ ret `shouldBe` [ Value (16 :: Double) ]
 
-    it "works with isNothing" $ run $ do
+    itDb "works with isNothing" $ do
         _   <- insert' p1
         p2e <- insert' p2
         _   <- insert' p3
@@ -970,19 +970,19 @@ testSelectWhere run = describe "select where_" $ do
                from $ \p -> do
                where_ $ isNothing (p ^. PersonAge)
                return p
-        liftIO $ ret `shouldBe` [ p2e ]
+        asserting $ ret `shouldBe` [ p2e ]
 
-    it "works with not_ . isNothing" $ run $ do
+    itDb "works with not_ . isNothing" $ do
         p1e <- insert' p1
         _   <- insert' p2
         ret <- select $
                from $ \p -> do
                where_ $ not_ (isNothing (p ^. PersonAge))
                return p
-        liftIO $ ret `shouldBe` [ p1e ]
+        asserting $ ret `shouldBe` [ p1e ]
 
-    it "works for a many-to-many implicit join" $
-      run $ do
+    itDb "works for a many-to-many implicit join" $
+      do
         p1e@(Entity p1k _) <- insert' p1
         p2e@(Entity p2k _) <- insert' p2
         _                  <- insert' p3
@@ -998,12 +998,12 @@ testSelectWhere run = describe "select where_" $ do
                orderBy [ asc (follower ^. PersonName)
                        , asc (followed ^. PersonName) ]
                return (follower, follows, followed)
-        liftIO $ ret `shouldBe` [ (p1e, f11, p1e)
+        asserting $ ret `shouldBe` [ (p1e, f11, p1e)
                                 , (p1e, f12, p2e)
                                 , (p4e, f42, p2e)
                                 , (p2e, f21, p1e) ]
 
-    it "works for a many-to-many explicit join" $ run $ do
+    itDb "works for a many-to-many explicit join" $ do
         p1e@(Entity p1k _) <- insert' p1
         p2e@(Entity p2k _) <- insert' p2
         _                  <- insert' p3
@@ -1019,13 +1019,13 @@ testSelectWhere run = describe "select where_" $ do
                orderBy [ asc (follower ^. PersonName)
                        , asc (followed ^. PersonName) ]
                return (follower, follows, followed)
-        liftIO $ ret `shouldBe` [ (p1e, f11, p1e)
+        asserting $ ret `shouldBe` [ (p1e, f11, p1e)
                                 , (p1e, f12, p2e)
                                 , (p4e, f42, p2e)
                                 , (p2e, f21, p1e) ]
 
-    it "works for a many-to-many explicit join and on order doesn't matter" $ do
-      run $ void $
+    itDb "works for a many-to-many explicit join and on order doesn't matter" $ do
+      void $
         selectRethrowingQuery $
         from $ \(person `InnerJoin` blog `InnerJoin` comment) -> do
         on $ person ^. PersonId ==. blog ^. BlogPostAuthorId
@@ -1033,9 +1033,9 @@ testSelectWhere run = describe "select where_" $ do
         pure (person, comment)
 
       -- we only care that we don't have a SQL error
-      True `shouldBe` True
+      asserting noExceptions
 
-    it "works for a many-to-many explicit join with LEFT OUTER JOINs" $ run $ do
+    itDb "works for a many-to-many explicit join with LEFT OUTER JOINs" $ do
         p1e@(Entity p1k _) <- insert' p1
         p2e@(Entity p2k _) <- insert' p2
         p3e                <- insert' p3
@@ -1051,13 +1051,13 @@ testSelectWhere run = describe "select where_" $ do
                orderBy [ asc ( follower ^. PersonName)
                        , asc (mfollowed ?. PersonName) ]
                return (follower, mfollows, mfollowed)
-        liftIO $ ret `shouldBe` [ (p1e, Just f11, Just p1e)
+        asserting $ ret `shouldBe` [ (p1e, Just f11, Just p1e)
                                 , (p1e, Just f12, Just p2e)
                                 , (p4e, Just f42, Just p2e)
                                 , (p3e, Nothing,  Nothing)
                                 , (p2e, Just f21, Just p1e) ]
 
-    it "works with a composite primary key" $ run $ do
+    itDb "works with a composite primary key" $ do
         let p = Point x y ""
             x = 10
             y = 15
@@ -1066,13 +1066,13 @@ testSelectWhere run = describe "select where_" $ do
         [Entity _ ret] <- select $ from $ \p' -> do
           where_ (p'^.PointId ==. val pPk)
           return p'
-        liftIO $ do
+        asserting $ do
           ret `shouldBe` p
           pPk `shouldBe` thePk
 
-testSelectOrderBy :: Run -> Spec
-testSelectOrderBy run = describe "select/orderBy" $ do
-    it "works with a single ASC field" $ run $ do
+testSelectOrderBy :: SpecDb
+testSelectOrderBy = describe "select/orderBy" $ do
+    itDb "works with a single ASC field" $ do
         p1e <- insert' p1
         p2e <- insert' p2
         p3e <- insert' p3
@@ -1080,9 +1080,9 @@ testSelectOrderBy run = describe "select/orderBy" $ do
                from $ \p -> do
                orderBy [asc $ p ^. PersonName]
                return p
-        liftIO $ ret `shouldBe` [ p1e, p3e, p2e ]
+        asserting $ ret `shouldBe` [ p1e, p3e, p2e ]
 
-    it "works with a sub_select" $ run $ do
+    itDb "works with a sub_select" $ do
         [p1k, p2k, p3k, p4k] <- mapM insert [p1, p2, p3, p4]
         [b1k, b2k, b3k, b4k] <- mapM (insert . BlogPost "") [p1k, p2k, p3k, p4k]
         ret <- select $
@@ -1093,20 +1093,20 @@ testSelectOrderBy run = describe "select/orderBy" $ do
                                return (p ^. PersonName)
                        ]
                return (b ^. BlogPostId)
-        liftIO $ ret `shouldBe` (Value <$> [b2k, b3k, b4k, b1k])
+        asserting $ ret `shouldBe` (Value <$> [b2k, b3k, b4k, b1k])
 
-    it "works on a composite primary key" $ run $ do
+    itDb "works on a composite primary key" $ do
         let ps = [Point 2 1 "", Point 1 2 ""]
         mapM_ insert ps
         eps <- select $
           from $ \p' -> do
             orderBy [asc (p'^.PointId)]
             return p'
-        liftIO $ map entityVal eps `shouldBe` reverse ps
+        asserting $ map entityVal eps `shouldBe` reverse ps
 
-testAscRandom :: SqlExpr (Value Double) -> Run -> Spec
-testAscRandom rand' run = describe "random_" $
-    it "asc random_ works" $ run $ do
+testAscRandom :: SqlExpr (Value Double) -> SpecDb
+testAscRandom rand' = describe "random_" $
+    itDb "asc random_ works" $ do
         _p1e <- insert' p1
         _p2e <- insert' p2
         _p3e <- insert' p3
@@ -1121,17 +1121,16 @@ testAscRandom rand' run = describe "random_" $
         -- There are 2^4 = 16 possible orderings.  The chance
         -- of 11 random samplings returning the same ordering
         -- is 1/2^40, so this test should pass almost everytime.
-        liftIO $ S.size rets `shouldSatisfy` (>2)
+        asserting $ S.size rets `shouldSatisfy` (>2)
 
-testSelectDistinct :: Run -> Spec
-testSelectDistinct run = do
+testSelectDistinct :: SpecDb
+testSelectDistinct = do
   describe "SELECT DISTINCT" $ do
     let selDistTest
-          :: (   forall m. RunDbMonad m
-              => SqlQuery (SqlExpr (Value String))
-              -> SqlPersistT (R.ResourceT m) [Value String])
-          -> IO ()
-        selDistTest q = run $ do
+          :: (   SqlQuery (SqlExpr (Value String))
+              -> SqlPersistT IO [Value String])
+          -> SqlPersistT IO Asserting
+        selDistTest q = do
           p1k <- insert p1
           let (t1, t2, t3) = ("a", "b", "c")
           mapM_ (insert . flip BlogPost p1k) [t1, t3, t2, t2, t1]
@@ -1140,25 +1139,25 @@ testSelectDistinct run = do
                  let title = b ^. BlogPostTitle
                  orderBy [asc title]
                  return title
-          liftIO $ ret `shouldBe` [ Value t1, Value t2, Value t3 ]
+          asserting $ ret `shouldBe` [ Value t1, Value t2, Value t3 ]
 
-    it "works on a simple example (select . distinct)" $
+    itDb "works on a simple example (select . distinct)" $
       selDistTest (\a -> select $ distinct a)
 
-    it "works on a simple example (distinct (return ()))" $
+    itDb "works on a simple example (distinct (return ()))" $
       selDistTest (\act -> select $ distinct (return ()) >> act)
 
 
 
-testCoasleceDefault :: Run -> Spec
-testCoasleceDefault run = describe "coalesce/coalesceDefault" $ do
-    it "works on a simple example" $ run $ do
+testCoasleceDefault :: SpecDb
+testCoasleceDefault = describe "coalesce/coalesceDefault" $ do
+    itDb "works on a simple example" $ do
         mapM_ insert' [p1, p2, p3, p4, p5]
         ret1 <- select $
                 from $ \p -> do
                 orderBy [asc (p ^. PersonId)]
                 return (coalesce [p ^. PersonAge, p ^. PersonWeight])
-        liftIO $ ret1 `shouldBe` [ Value (Just (36 :: Int))
+        asserting $ ret1 `shouldBe` [ Value (Just (36 :: Int))
                                  , Value (Just 37)
                                  , Value (Just 17)
                                  , Value (Just 17)
@@ -1169,14 +1168,14 @@ testCoasleceDefault run = describe "coalesce/coalesceDefault" $ do
                 from $ \p -> do
                 orderBy [asc (p ^. PersonId)]
                 return (coalesceDefault [p ^. PersonAge, p ^. PersonWeight] (p ^. PersonFavNum))
-        liftIO $ ret2 `shouldBe` [ Value (36 :: Int)
+        asserting $ ret2 `shouldBe` [ Value (36 :: Int)
                                  , Value 37
                                  , Value 17
                                  , Value 17
                                  , Value 5
                                  ]
 
-    it "works with sub-queries" $ run $ do
+    itDb "works with sub-queries" $ do
         p1id <- insert p1
         p2id <- insert p2
         p3id <- insert p3
@@ -1192,15 +1191,15 @@ testCoasleceDefault run = describe "coalesce/coalesceDefault" $ do
                          where_ (p ^. PersonId ==. b ^. BlogPostAuthorId)
                          return $ p ^. PersonAge
                  return $ coalesceDefault [sub_select sub] (val (42 :: Int))
-        liftIO $ ret `shouldBe` [ Value (36 :: Int)
+        asserting $ ret `shouldBe` [ Value (36 :: Int)
                                 , Value 42
                                 , Value 17
                                 ]
 
 
-testDelete :: Run -> Spec
-testDelete run = describe "delete" $ do
-    it "works on a simple example" $ run $ do
+testDelete :: SpecDb
+testDelete = describe "delete" $ do
+    itDb "works on a simple example" $ do
         p1e <- insert' p1
         p2e <- insert' p2
         p3e <- insert' p3
@@ -1209,21 +1208,21 @@ testDelete run = describe "delete" $ do
                      orderBy [asc (p ^. PersonName)]
                      return p
         ret1 <- getAll
-        liftIO $ ret1 `shouldBe` [ p1e, p3e, p2e ]
+        asserting $ ret1 `shouldBe` [ p1e, p3e, p2e ]
         ()   <- delete $
                 from $ \p ->
                 where_ (p ^. PersonName ==. val (personName p1))
         ret2 <- getAll
-        liftIO $ ret2 `shouldBe` [ p3e, p2e ]
+        asserting $ ret2 `shouldBe` [ p3e, p2e ]
         n    <- deleteCount $
                 from $ \p ->
                 return ((p :: SqlExpr (Entity Person)) `seq` ())
         ret3 <- getAll
-        liftIO $ (n, ret3) `shouldBe` (2, [])
+        asserting $ (n, ret3) `shouldBe` (2, [])
 
-testUpdate :: Run -> Spec
-testUpdate run = describe "update" $ do
-    it "works with a subexpression having COUNT(*)" $ run $ do
+testUpdate :: SpecDb
+testUpdate = describe "update" $ do
+    itDb "works with a subexpression having COUNT(*)" $ do
         p1k <- insert p1
         p2k <- insert p2
         p3k <- insert p3
@@ -1239,14 +1238,14 @@ testUpdate run = describe "update" $ do
                from $ \p -> do
                orderBy [ asc (p ^. PersonName) ]
                return p
-        liftIO $ ret `shouldBe` [ Entity p1k p1 { personAge = Just 3 }
+        asserting $ ret `shouldBe` [ Entity p1k p1 { personAge = Just 3 }
                                 , Entity p3k p3 { personAge = Just 7 }
                                 , Entity p2k p2 { personAge = Just 0 } ]
 
-    it "works with a composite primary key" $
+    it "works with a composite primary key" $ \_ ->
         pendingWith "Need refactor to support composite pks on ESet"
       {-
-      run $ do
+      do
         let p = Point x y ""
             x = 10
             y = 15
@@ -1257,11 +1256,11 @@ testUpdate run = describe "update" $ do
         () <- update $ \p' -> do
               set p' [PointId =. val newPk]
         [Entity _ ret] <- select $ from $ return
-        liftIO $ do
+        asserting $ do
           ret `shouldBe` Point newX newY []
       -}
 
-    it "GROUP BY works with COUNT" $ run $ do
+    itDb "GROUP BY works with COUNT" $ do
         p1k <- insert p1
         p2k <- insert p2
         p3k <- insert p3
@@ -1274,11 +1273,11 @@ testUpdate run = describe "update" $ do
                let cnt = count (b ^. BlogPostId)
                orderBy [ asc cnt ]
                return (p, cnt)
-        liftIO $ ret `shouldBe` [ (Entity p2k p2, Value (0 :: Int))
+        asserting $ ret `shouldBe` [ (Entity p2k p2, Value (0 :: Int))
                                 , (Entity p1k p1, Value 3)
                                 , (Entity p3k p3, Value 7) ]
 
-    it "GROUP BY works with composite primary key" $ run $ do
+    itDb "GROUP BY works with composite primary key" $ do
         p1k <- insert $ Point 1 2 "asdf"
         p2k <- insert $ Point 2 3 "asdf"
         ret <-
@@ -1287,13 +1286,13 @@ testUpdate run = describe "update" $ do
             where_ $ point ^. PointName ==. val "asdf"
             groupBy (point ^. PointId)
             pure (point ^. PointId)
-        liftIO $ do
+        asserting $ do
             ret `shouldMatchList`
                 map Value [p1k, p2k]
 
 
 
-    it "GROUP BY works with COUNT and InnerJoin" $ run $ do
+    itDb "GROUP BY works with COUNT and InnerJoin" $ do
         l1k <- insert l1
         l3k <- insert l3
         mapM_ (\k -> insert $ Deed k l1k) (map show [1..3 :: Int])
@@ -1305,10 +1304,10 @@ testUpdate run = describe "update" $ do
           on $ lord ^. LordId ==. deed ^. DeedOwnerId
           groupBy (lord ^. LordId)
           return (lord ^. LordId, count $ deed ^. DeedId)
-        liftIO $ ret `shouldMatchList` [ (Value l3k, Value 7)
+        asserting $ ret `shouldMatchList` [ (Value l3k, Value 7)
                                        , (Value l1k, Value 3) ]
 
-    it "GROUP BY works with nested tuples" $ run $ do
+    itDb "GROUP BY works with nested tuples" $ do
         l1k <- insert l1
         l3k <- insert l3
         mapM_ (\k -> insert $ Deed k l1k) (map show [1..3 :: Int])
@@ -1320,9 +1319,9 @@ testUpdate run = describe "update" $ do
           on $ lord ^. LordId ==. deed ^. DeedOwnerId
           groupBy ((lord ^. LordId, lord ^. LordDogs), deed ^. DeedContract)
           return (lord ^. LordId, count $ deed ^. DeedId)
-        liftIO $ length ret `shouldBe` 10
+        asserting $ length ret `shouldBe` 10
 
-    it "GROUP BY works with HAVING" $ run $ do
+    itDb "GROUP BY works with HAVING" $ do
         p1k <- insert p1
         _p2k <- insert p2
         p3k <- insert p3
@@ -1336,7 +1335,7 @@ testUpdate run = describe "update" $ do
                having (cnt >. (val 0))
                orderBy [ asc cnt ]
                return (p, cnt)
-        liftIO $ ret `shouldBe` [ (Entity p1k p1, Value (3 :: Int))
+        asserting $ ret `shouldBe` [ (Entity p1k p1, Value (3 :: Int))
                                 , (Entity p3k p3, Value 7) ]
 
 -- we only care that this compiles. check that SqlWriteT doesn't fail on
@@ -1365,9 +1364,9 @@ testSqlReadT =
   groupBy (lord ^. LordId)
   return (lord ^. LordId, count $ deed ^. DeedId)
 
-testListOfValues :: Run -> Spec
-testListOfValues run = describe "lists of values" $ do
-    it "IN works for valList" $ run $ do
+testListOfValues :: SpecDb
+testListOfValues = describe "lists of values" $ do
+    itDb "IN works for valList" $ do
         p1k <- insert p1
         p2k <- insert p2
         _p3k <- insert p3
@@ -1375,10 +1374,10 @@ testListOfValues run = describe "lists of values" $ do
                from $ \p -> do
                where_ (p ^. PersonName `in_` valList (personName <$> [p1, p2]))
                return p
-        liftIO $ ret `shouldBe` [ Entity p1k p1
+        asserting $ ret `shouldBe` [ Entity p1k p1
                                 , Entity p2k p2 ]
 
-    it "IN works for valList (null list)" $ run $ do
+    itDb "IN works for valList (null list)" $ do
         _p1k <- insert p1
         _p2k <- insert p2
         _p3k <- insert p3
@@ -1386,9 +1385,9 @@ testListOfValues run = describe "lists of values" $ do
                from $ \p -> do
                where_ (p ^. PersonName `in_` valList [])
                return p
-        liftIO $ ret `shouldBe` []
+        asserting $ ret `shouldBe` []
 
-    it "IN works for subList_select" $ run $ do
+    itDb "IN works for subList_select" $ do
         p1k <- insert p1
         _p2k <- insert p2
         p3k <- insert p3
@@ -1402,9 +1401,9 @@ testListOfValues run = describe "lists of values" $ do
                      return (bp ^. BlogPostAuthorId)
                where_ (p ^. PersonId `in_` subList_select subquery)
                return p
-        liftIO $ L.sort ret `shouldBe` L.sort [Entity p1k p1, Entity p3k p3]
+        asserting $ L.sort ret `shouldBe` L.sort [Entity p1k p1, Entity p3k p3]
 
-    it "NOT IN works for subList_select" $ run $ do
+    itDb "NOT IN works for subList_select" $ do
         p1k <- insert p1
         p2k <- insert p2
         p3k <- insert p3
@@ -1417,9 +1416,9 @@ testListOfValues run = describe "lists of values" $ do
                      return (bp ^. BlogPostAuthorId)
                where_ (p ^. PersonId `notIn` subList_select subquery)
                return p
-        liftIO $ ret `shouldBe` [ Entity p2k p2 ]
+        asserting $ ret `shouldBe` [ Entity p2k p2 ]
 
-    it "EXISTS works for subList_select" $ run $ do
+    itDb "EXISTS works for subList_select" $ do
         p1k <- insert p1
         _p2k <- insert p2
         p3k <- insert p3
@@ -1432,10 +1431,10 @@ testListOfValues run = describe "lists of values" $ do
                         where_ (bp ^. BlogPostAuthorId ==. p ^. PersonId)
                orderBy [asc (p ^. PersonName)]
                return p
-        liftIO $ ret `shouldBe` [ Entity p1k p1
+        asserting $ ret `shouldBe` [ Entity p1k p1
                                 , Entity p3k p3 ]
 
-    it "EXISTS works for subList_select" $ run $ do
+    itDb "EXISTS works for subList_select" $ do
         p1k <- insert p1
         p2k <- insert p2
         p3k <- insert p3
@@ -1447,55 +1446,56 @@ testListOfValues run = describe "lists of values" $ do
                         from $ \bp -> do
                         where_ (bp ^. BlogPostAuthorId ==. p ^. PersonId)
                return p
-        liftIO $ ret `shouldBe` [ Entity p2k p2 ]
+        asserting $ ret `shouldBe` [ Entity p2k p2 ]
 
-testListFields :: Run -> Spec
-testListFields run = describe "list fields" $ do
+testListFields :: SpecDb
+testListFields = describe "list fields" $ do
     -- <https://github.com/prowdsponsor/esqueleto/issues/100>
-    it "can update list fields" $ run $ do
+    itDb "can update list fields" $ do
         cclist <- insert $ CcList []
         update $ \p -> do
             set p [ CcListNames =. val ["fred"]]
             where_ (p ^. CcListId ==. val cclist)
+        asserting noExceptions
 
-testInsertsBySelect :: Run -> Spec
-testInsertsBySelect run = do
+testInsertsBySelect :: SpecDb
+testInsertsBySelect = do
   describe "inserts by select" $ do
-    it "IN works for insertSelect" $
-      run $ do
+    itDb "IN works for insertSelect" $
+      do
         _ <- insert p1
         _ <- insert p2
         _ <- insert p3
         insertSelect $ from $ \p -> do
           return $ BlogPost <# val "FakePost" <&> (p ^. PersonId)
         ret <- select $ from (\(_::(SqlExpr (Entity BlogPost))) -> return countRows)
-        liftIO $ ret `shouldBe` [Value (3::Int)]
+        asserting $ ret `shouldBe` [Value (3::Int)]
 
 
 
 
 
-testInsertsBySelectReturnsCount :: Run -> Spec
-testInsertsBySelectReturnsCount run = do
+testInsertsBySelectReturnsCount :: SpecDb
+testInsertsBySelectReturnsCount = do
   describe "inserts by select, returns count" $ do
-    it "IN works for insertSelectCount" $
-      run $ do
+    itDb "IN works for insertSelectCount" $
+      do
         _ <- insert p1
         _ <- insert p2
         _ <- insert p3
         cnt <- insertSelectCount $ from $ \p -> do
           return $ BlogPost <# val "FakePost" <&> (p ^. PersonId)
         ret <- select $ from (\(_::(SqlExpr (Entity BlogPost))) -> return countRows)
-        liftIO $ ret `shouldBe` [Value (3::Int)]
-        liftIO $ cnt `shouldBe` 3
+        asserting $ ret `shouldBe` [Value (3::Int)]
+        asserting $ cnt `shouldBe` 3
 
 
 
 
-testRandomMath :: Run -> Spec
-testRandomMath run = describe "random_ math" $
-    it "rand returns result in random order" $
-      run $ do
+testRandomMath :: SpecDb
+testRandomMath = describe "random_ math" $
+    itDb "rand returns result in random order" $
+      do
         replicateM_ 20 $ do
           _ <- insert p1
           _ <- insert p2
@@ -1512,13 +1512,13 @@ testRandomMath run = describe "random_ math" $
                   orderBy [rand]
                   return (p ^. PersonId)
 
-        liftIO $ (ret1 == ret2) `shouldBe` False
+        asserting $ (ret1 == ret2) `shouldBe` False
 
-testMathFunctions :: Run -> Spec
-testMathFunctions run = do
+testMathFunctions :: SpecDb
+testMathFunctions = do
   describe "Math-related functions" $ do
-    it "castNum works for multiplying Int and Double" $
-      run $ do
+    itDb "castNum works for multiplying Int and Double" $
+      do
         mapM_ insert [Numbers 2 3.4, Numbers 7 1.1]
         ret <-
           select $
@@ -1526,39 +1526,39 @@ testMathFunctions run = do
           let r = castNum (n ^. NumbersInt) *. n ^. NumbersDouble
           orderBy [asc r]
           return r
-        liftIO $ length ret `shouldBe` 2
+        asserting $ length ret `shouldBe` 2
         let [Value a, Value b] = ret
-        liftIO $ max (abs (a - 6.8)) (abs (b - 7.7)) `shouldSatisfy` (< 0.01)
+        asserting $ max (abs (a - 6.8)) (abs (b - 7.7)) `shouldSatisfy` (< 0.01)
 
 
 
 
 
-testCase :: Run -> Spec
-testCase run = do
+testCase :: SpecDb
+testCase = do
   describe "case" $ do
-    it "Works for a simple value based when - False" $
-      run $ do
+    itDb "Works for a simple value based when - False" $
+      do
         ret <- select $
           return $
             case_
               [ when_ (val False) then_ (val (1 :: Int)) ]
               (else_ (val 2))
 
-        liftIO $ ret `shouldBe` [ Value 2 ]
+        asserting $ ret `shouldBe` [ Value 2 ]
 
-    it "Works for a simple value based when - True" $
-      run $ do
+    itDb "Works for a simple value based when - True" $
+      do
         ret <- select $
           return $
             case_
               [ when_ (val True) then_ (val (1 :: Int)) ]
               (else_ (val 2))
 
-        liftIO $ ret `shouldBe` [ Value 1 ]
+        asserting $ ret `shouldBe` [ Value 1 ]
 
-    it "works for a semi-complicated query" $
-      run $ do
+    itDb "works for a semi-complicated query" $
+      do
         _ <- insert p1
         _ <- insert p2
         _ <- insert p3
@@ -1580,14 +1580,14 @@ testCase run = do
                       return $ count (v ^. PersonName) +. val (1 :: Int)) ]
               (else_ $ val (-1))
 
-        liftIO $ ret `shouldBe` [ Value (3) ]
+        asserting $ ret `shouldBe` [ Value (3) ]
 
 
 
 
 
-testLocking :: WithConn (NoLoggingT IO) [TL.Text] -> Spec
-testLocking withConn = do
+testLocking :: SpecDb
+testLocking = do
   describe "locking" $ do
     -- The locking clause is the last one, so try to use many
     -- others to test if it's at the right position.  We don't
@@ -1620,31 +1620,33 @@ testLocking withConn = do
               toText conn q =
                 let (tlb, _) = EI.toRawSql EI.SELECT (conn, EI.initialIdentState) q
                 in TLB.toLazyText tlb
+          conn <- ask
           [complex, with1, with2, with3] <-
-            runNoLoggingT $ withConn $ \conn -> return $
+            return $
               map (toText conn) [complexQuery, queryWithClause1, queryWithClause2, queryWithClause3]
           let expected = complex <> "\n" <> syntax
-          (with1, with2, with3) `shouldBe` (expected, expected, expected)
+          asserting $
+              (with1, with2, with3) `shouldBe` (expected, expected, expected)
 
-    it "looks sane for ForUpdate"           $ sanityCheck ForUpdate           "FOR UPDATE"
-    it "looks sane for ForUpdateSkipLocked" $ sanityCheck ForUpdateSkipLocked "FOR UPDATE SKIP LOCKED"
-    it "looks sane for ForShare"            $ sanityCheck ForShare            "FOR SHARE"
-    it "looks sane for LockInShareMode"     $ sanityCheck LockInShareMode     "LOCK IN SHARE MODE"
-
-
-
+    itDb "looks sane for ForUpdate"           $ sanityCheck ForUpdate           "FOR UPDATE"
+    itDb "looks sane for ForUpdateSkipLocked" $ sanityCheck ForUpdateSkipLocked "FOR UPDATE SKIP LOCKED"
+    itDb "looks sane for ForShare"            $ sanityCheck ForShare            "FOR SHARE"
+    itDb "looks sane for LockInShareMode"     $ sanityCheck LockInShareMode     "LOCK IN SHARE MODE"
 
 
-testCountingRows :: Run -> Spec
-testCountingRows run = do
+
+
+
+testCountingRows :: SpecDb
+testCountingRows = do
   describe "counting rows" $ do
     forM_ [ ("count (test A)",    count . (^. PersonAge),         4)
           , ("count (test B)",    count . (^. PersonWeight),      5)
           , ("countRows",         const countRows,                5)
           , ("countDistinct",     countDistinct . (^. PersonAge), 2) ] $
       \(title, countKind, expected) ->
-      it (title ++ " works as expected") $
-        run $ do
+      itDb (title ++ " works as expected") $
+        do
           mapM_ insert
             [ Person "" (Just 1) (Just 1) 1
             , Person "" (Just 2) (Just 1) 1
@@ -1652,50 +1654,53 @@ testCountingRows run = do
             , Person "" (Just 2) (Just 2) 1
             , Person "" Nothing  (Just 3) 1]
           [Value n] <- select $ from $ return . countKind
-          liftIO $ (n :: Int) `shouldBe` expected
+          asserting $ (n :: Int) `shouldBe` expected
 
-testRenderSql :: Run -> Spec
-testRenderSql run = do
+testRenderSql :: SpecDb
+testRenderSql = do
   describe "testRenderSql" $ do
-    it "works" $ do
-      (queryText, queryVals) <- run $ renderQuerySelect $
+    itDb "works" $ do
+      (queryText, queryVals) <- renderQuerySelect $
         from $ \p -> do
         where_ $ p ^. PersonName ==. val "Johhny Depp"
         pure (p ^. PersonName, p ^. PersonAge)
       -- the different backends use different quote marks, so I filter them out
       -- here instead of making a duplicate test
-      Text.filter (\c -> c `notElem` ['`', '"']) queryText
-        `shouldBe`
-          Text.unlines
-            [ "SELECT Person.name, Person.age"
-            , "FROM Person"
-            , "WHERE Person.name = ?"
-            ]
-      queryVals
-        `shouldBe`
-          [toPersistValue ("Johhny Depp" :: TL.Text)]
+      asserting $ do
+          Text.filter (\c -> c `notElem` ['`', '"']) queryText
+            `shouldBe`
+              Text.unlines
+                [ "SELECT Person.name, Person.age"
+                , "FROM Person"
+                , "WHERE Person.name = ?"
+                ]
+          queryVals
+            `shouldBe`
+              [toPersistValue ("Johhny Depp" :: TL.Text)]
 
   describe "renderExpr" $ do
-    it "renders a value" $ do
-      (c, expr) <- run $ do
+    itDb "renders a value" $ do
+      (c, expr) <- do
         conn <- ask
         let Right c = P.mkEscapeChar conn
         let user = EI.unsafeSqlEntity (EI.I "user")
             blogPost = EI.unsafeSqlEntity (EI.I "blog_post")
         pure $ (,) c $ EI.renderExpr conn $
           user ^. PersonId ==. blogPost ^. BlogPostAuthorId
-      expr
-        `shouldBe`
-          Text.intercalate (Text.singleton c) ["", "user", ".", "id", ""]
-          <>
-          " = "
-          <>
-          Text.intercalate (Text.singleton c) ["", "blog_post", ".", "authorId", ""]
-    it "renders ? for a val" $ do
-      expr <- run $ ask >>= \c -> pure $ EI.renderExpr c (val (PersonKey 0) ==. val (PersonKey 1))
-      expr `shouldBe` "? = ?"
+      asserting $ do
+          expr
+            `shouldBe`
+              Text.intercalate (Text.singleton c) ["", "user", ".", "id", ""]
+              <>
+              " = "
+              <>
+              Text.intercalate (Text.singleton c) ["", "blog_post", ".", "authorId", ""]
 
-  describe "ExprParser" $ do
+    itDb "renders ? for a val" $ do
+      expr <- ask >>= \c -> pure $ EI.renderExpr c (val (PersonKey 0) ==. val (PersonKey 1))
+      asserting $ expr `shouldBe` "? = ?"
+
+  beforeWith (\_ -> pure ()) $ describe "ExprParser" $ do
     let parse parser = AP.parseOnly (parser '#')
     describe "parseEscapedChars" $ do
       let subject = parse P.parseEscapedChars
@@ -1786,402 +1791,402 @@ testRenderSql run = do
                 }
               ]
 
-testOnClauseOrder :: Run -> Spec
-testOnClauseOrder run = describe "On Clause Ordering" $ do
-  let
-    setup :: MonadIO m => SqlPersistT m ()
-    setup = do
-      ja1 <- insert (JoinOne "j1 hello")
-      ja2 <- insert (JoinOne "j1 world")
-      jb1 <- insert (JoinTwo ja1 "j2 hello")
-      jb2 <- insert (JoinTwo ja1 "j2 world")
-      jb3 <- insert (JoinTwo ja2 "j2 foo")
-      _ <- insert (JoinTwo ja2 "j2 bar")
-      jc1 <- insert (JoinThree jb1 "j3 hello")
-      jc2 <- insert (JoinThree jb1 "j3 world")
-      _ <- insert (JoinThree jb2 "j3 foo")
-      _ <- insert (JoinThree jb3 "j3 bar")
-      _ <- insert (JoinThree jb3 "j3 baz")
-      _ <- insert (JoinFour "j4 foo" jc1)
-      _ <- insert (JoinFour "j4 bar" jc2)
-      jd1 <- insert (JoinOther "foo")
-      jd2 <- insert (JoinOther "bar")
-      _ <- insert (JoinMany "jm foo hello" jd1 ja1)
-      _ <- insert (JoinMany "jm foo world" jd1 ja2)
-      _ <- insert (JoinMany "jm bar hello" jd2 ja1)
-      _ <- insert (JoinMany "jm bar world" jd2 ja2)
-      pure ()
-  describe "identical results for" $ do
-    it "three tables" $ do
-      abcs <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c) -> do
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          pure (a, b, c)
-      acbs <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c) -> do
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          pure (a, b, c)
+testOnClauseOrder :: SpecDb
+testOnClauseOrder = describe "On Clause Ordering" $ do
+    let
+        setup :: MonadIO m => SqlPersistT m ()
+        setup = do
+            ja1 <- insert (JoinOne "j1 hello")
+            ja2 <- insert (JoinOne "j1 world")
+            jb1 <- insert (JoinTwo ja1 "j2 hello")
+            jb2 <- insert (JoinTwo ja1 "j2 world")
+            jb3 <- insert (JoinTwo ja2 "j2 foo")
+            _ <- insert (JoinTwo ja2 "j2 bar")
+            jc1 <- insert (JoinThree jb1 "j3 hello")
+            jc2 <- insert (JoinThree jb1 "j3 world")
+            _ <- insert (JoinThree jb2 "j3 foo")
+            _ <- insert (JoinThree jb3 "j3 bar")
+            _ <- insert (JoinThree jb3 "j3 baz")
+            _ <- insert (JoinFour "j4 foo" jc1)
+            _ <- insert (JoinFour "j4 bar" jc2)
+            jd1 <- insert (JoinOther "foo")
+            jd2 <- insert (JoinOther "bar")
+            _ <- insert (JoinMany "jm foo hello" jd1 ja1)
+            _ <- insert (JoinMany "jm foo world" jd1 ja2)
+            _ <- insert (JoinMany "jm bar hello" jd2 ja1)
+            _ <- insert (JoinMany "jm bar world" jd2 ja2)
+            pure ()
+    describe "identical results for" $ do
+        itDb "three tables" $ do
+            setup
+            abcs <-
+                select $
+                from $ \(a `InnerJoin` b `InnerJoin` c) -> do
+                on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+                on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+                pure (a, b, c)
+            acbs <-
+                select $
+                from $ \(a `InnerJoin` b `InnerJoin` c) -> do
+                on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+                on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+                pure (a, b, c)
 
-      listsEqualOn abcs acbs $ \(Entity _ j1, Entity _ j2, Entity _ j3) ->
-        (joinOneName j1, joinTwoName j2, joinThreeName j3)
+            asserting $ do
+                listsEqualOn abcs acbs $ \(Entity _ j1, Entity _ j2, Entity _ j3) ->
+                  (joinOneName j1, joinTwoName j2, joinThreeName j3)
 
-    it "four tables" $ do
-      xs0 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          pure (a, b, c, d)
-      xs1 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          pure (a, b, c, d)
-      xs2 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          pure (a, b, c, d)
-      xs3 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          pure (a, b, c, d)
-      xs4 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          pure (a, b, c, d)
+        itDb "four tables" $ do
+            setup
+            xs0 <-
+                select $
+                from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
+                on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+                on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+                on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+                pure (a, b, c, d)
+            xs1 <-
+                select $
+                from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
+                on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+                on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+                on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+                pure (a, b, c, d)
+            xs2 <-
+                select $
+                from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
+                on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+                on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+                on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+                pure (a, b, c, d)
+            xs3 <-
+                select $
+                from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
+                on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+                on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+                on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+                pure (a, b, c, d)
+            xs4 <-
+                select $
+                from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
+                on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+                on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+                on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+                pure (a, b, c, d)
 
-      let getNames (j1, j2, j3, j4) =
-            ( joinOneName (entityVal j1)
-            , joinTwoName (entityVal j2)
-            , joinThreeName (entityVal j3)
-            , joinFourName (entityVal j4)
-            )
-      listsEqualOn xs0 xs1 getNames
-      listsEqualOn xs0 xs2 getNames
-      listsEqualOn xs0 xs3 getNames
-      listsEqualOn xs0 xs4 getNames
+            let
+                getNames (j1, j2, j3, j4) =
+                    ( joinOneName (entityVal j1)
+                    , joinTwoName (entityVal j2)
+                    , joinThreeName (entityVal j3)
+                    , joinFourName (entityVal j4)
+                    )
+            asserting $ do
+                listsEqualOn xs0 xs1 getNames
+                listsEqualOn xs0 xs2 getNames
+                listsEqualOn xs0 xs3 getNames
+                listsEqualOn xs0 xs4 getNames
 
-    it "associativity of innerjoin" $ do
-      xs0 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          pure (a, b, c, d)
+        itDb "associativity of innerjoin" $ do
+          setup
+          xs0 <-
+            select $
+              from $ \(a `InnerJoin` b `InnerJoin` c `InnerJoin` d) -> do
+              on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+              on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+              on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+              pure (a, b, c, d)
 
-      xs1 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` (c `InnerJoin` d)) -> do
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          pure (a, b, c, d)
+          xs1 <-
+            select $
+              from $ \(a `InnerJoin` b `InnerJoin` (c `InnerJoin` d)) -> do
+              on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+              on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+              on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+              pure (a, b, c, d)
 
-      xs2 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` (b `InnerJoin` c) `InnerJoin` d) -> do
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          pure (a, b, c, d)
+          xs2 <-
+            select $
+              from $ \(a `InnerJoin` (b `InnerJoin` c) `InnerJoin` d) -> do
+              on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+              on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+              on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+              pure (a, b, c, d)
 
-      xs3 <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` (b `InnerJoin` c `InnerJoin` d)) -> do
-          on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
-          on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
-          on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
-          pure (a, b, c, d)
+          xs3 <-
+            select $
+              from $ \(a `InnerJoin` (b `InnerJoin` c `InnerJoin` d)) -> do
+              on (a ^. JoinOneId ==. b ^. JoinTwoJoinOne)
+              on (b ^. JoinTwoId ==. c ^. JoinThreeJoinTwo)
+              on (c ^. JoinThreeId ==. d ^. JoinFourJoinThree)
+              pure (a, b, c, d)
 
-      let getNames (j1, j2, j3, j4) =
-            ( joinOneName (entityVal j1)
-            , joinTwoName (entityVal j2)
-            , joinThreeName (entityVal j3)
-            , joinFourName (entityVal j4)
-            )
-      listsEqualOn xs0 xs1 getNames
-      listsEqualOn xs0 xs2 getNames
-      listsEqualOn xs0 xs3 getNames
+          let getNames (j1, j2, j3, j4) =
+                ( joinOneName (entityVal j1)
+                , joinTwoName (entityVal j2)
+                , joinThreeName (entityVal j3)
+                , joinFourName (entityVal j4)
+                )
+          asserting $ do
+              listsEqualOn xs0 xs1 getNames
+              listsEqualOn xs0 xs2 getNames
+              listsEqualOn xs0 xs3 getNames
 
-    it "inner join on two entities" $ do
-      (xs0, xs1) <- run $ do
-        pid <- insert $ Person "hello" Nothing Nothing 3
-        _ <- insert $ BlogPost "good poast" pid
-        _ <- insert $ Profile "cool" pid
-        xs0 <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr) -> do
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          pure (p, b, pr)
-        xs1 <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr) -> do
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          pure (p, b, pr)
-        pure (xs0, xs1)
-      listsEqualOn xs0 xs1 $ \(Entity _ p, Entity _ b, Entity _ pr) ->
-        (personName p, blogPostTitle b, profileName pr)
-    it "inner join on three entities" $ do
-      res <- run $ do
-        pid <- insert $ Person "hello" Nothing Nothing 3
-        _ <- insert $ BlogPost "good poast" pid
-        _ <- insert $ BlogPost "good poast #2" pid
-        _ <- insert $ Profile "cool" pid
-        _ <- insert $ Reply pid "u wot m8"
-        _ <- insert $ Reply pid "how dare you"
+        itDb "inner join on two entities" $ do
+          (xs0, xs1) <- do
+            pid <- insert $ Person "hello" Nothing Nothing 3
+            _ <- insert $ BlogPost "good poast" pid
+            _ <- insert $ Profile "cool" pid
+            xs0 <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr) -> do
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              pure (p, b, pr)
+            xs1 <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr) -> do
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              pure (p, b, pr)
+            pure (xs0, xs1)
+          asserting $ listsEqualOn xs0 xs1 $ \(Entity _ p, Entity _ b, Entity _ pr) ->
+            (personName p, blogPostTitle b, profileName pr)
+        itDb "inner join on three entities" $ do
+          res <- do
+            pid <- insert $ Person "hello" Nothing Nothing 3
+            _ <- insert $ BlogPost "good poast" pid
+            _ <- insert $ BlogPost "good poast #2" pid
+            _ <- insert $ Profile "cool" pid
+            _ <- insert $ Reply pid "u wot m8"
+            _ <- insert $ Reply pid "how dare you"
 
-        bprr <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          on $ p ^. PersonId ==. r ^. ReplyGuy
-          pure (p, b, pr, r)
+            bprr <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              on $ p ^. PersonId ==. r ^. ReplyGuy
+              pure (p, b, pr, r)
 
-        brpr <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          on $ p ^. PersonId ==. r ^. ReplyGuy
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          pure (p, b, pr, r)
+            brpr <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              on $ p ^. PersonId ==. r ^. ReplyGuy
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              pure (p, b, pr, r)
 
-        prbr <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          on $ p ^. PersonId ==. r ^. ReplyGuy
-          pure (p, b, pr, r)
+            prbr <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              on $ p ^. PersonId ==. r ^. ReplyGuy
+              pure (p, b, pr, r)
 
-        prrb <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          on $ p ^. PersonId ==. r ^. ReplyGuy
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          pure (p, b, pr, r)
+            prrb <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              on $ p ^. PersonId ==. r ^. ReplyGuy
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              pure (p, b, pr, r)
 
-        rprb <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
-          on $ p ^. PersonId ==. r ^. ReplyGuy
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          pure (p, b, pr, r)
+            rprb <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
+              on $ p ^. PersonId ==. r ^. ReplyGuy
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              pure (p, b, pr, r)
 
-        rbpr <- selectRethrowingQuery $
-          from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
-          on $ p ^. PersonId ==. r ^. ReplyGuy
-          on $ p ^. PersonId ==. b ^. BlogPostAuthorId
-          on $ p ^. PersonId ==. pr ^. ProfilePerson
-          pure (p, b, pr, r)
+            rbpr <- selectRethrowingQuery $
+              from $ \(p `InnerJoin` b `InnerJoin` pr `InnerJoin` r) -> do
+              on $ p ^. PersonId ==. r ^. ReplyGuy
+              on $ p ^. PersonId ==. b ^. BlogPostAuthorId
+              on $ p ^. PersonId ==. pr ^. ProfilePerson
+              pure (p, b, pr, r)
 
-        pure [bprr, brpr, prbr, prrb, rprb, rbpr]
-      forM_ (zip res (drop 1 (cycle res))) $ \(a, b) -> a `shouldBe` b
+            pure [bprr, brpr, prbr, prrb, rprb, rbpr]
+          asserting $ forM_ (zip res (drop 1 (cycle res))) $ \(a, b) -> a `shouldBe` b
 
-    it "many-to-many" $ do
-      ac <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c) -> do
-          on (a ^. JoinOneId ==. b ^. JoinManyJoinOne)
-          on (c ^. JoinOtherId ==. b ^. JoinManyJoinOther)
-          pure (a, c)
+        itDb "many-to-many" $ do
+          ac <- do
+            setup
+            select $
+              from $ \(a `InnerJoin` b `InnerJoin` c) -> do
+              on (a ^. JoinOneId ==. b ^. JoinManyJoinOne)
+              on (c ^. JoinOtherId ==. b ^. JoinManyJoinOther)
+              pure (a, c)
 
-      ca <- run $ do
-        setup
-        select $
-          from $ \(a `InnerJoin` b `InnerJoin` c) -> do
-          on (c ^. JoinOtherId ==. b ^. JoinManyJoinOther)
-          on (a ^. JoinOneId ==. b ^. JoinManyJoinOne)
-          pure (a, c)
+          ca <- do
+            setup
+            select $
+              from $ \(a `InnerJoin` b `InnerJoin` c) -> do
+              on (c ^. JoinOtherId ==. b ^. JoinManyJoinOther)
+              on (a ^. JoinOneId ==. b ^. JoinManyJoinOne)
+              pure (a, c)
 
-      listsEqualOn ac ca $ \(Entity _ a, Entity _ b) ->
-        (joinOneName a, joinOtherName b)
+          asserting $ listsEqualOn ac ca $ \(Entity _ a, Entity _ b) ->
+            (joinOneName a, joinOtherName b)
 
-    it "left joins on order" $ do
-      ca <- run $ do
-        setup
-        select $
-          from $ \(a `LeftOuterJoin` b `InnerJoin` c) -> do
-          on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
-          on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
-          orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
-          pure (a, c)
-      ac <- run $ do
-        setup
-        select $
-          from $ \(a `LeftOuterJoin` b `InnerJoin` c) -> do
-          on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
-          on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
-          orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
-          pure (a, c)
+        itDb "left joins on order" $ do
+          ca <- do
+            setup
+            select $
+              from $ \(a `LeftOuterJoin` b `InnerJoin` c) -> do
+              on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
+              on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
+              orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
+              pure (a, c)
+          ac <- do
+            setup
+            select $
+              from $ \(a `LeftOuterJoin` b `InnerJoin` c) -> do
+              on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
+              on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
+              orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
+              pure (a, c)
 
-      listsEqualOn ac ca $ \(Entity _ a, b) ->
-        (joinOneName a, maybe "NULL" (joinOtherName . entityVal) b)
+          asserting $ listsEqualOn ac ca $ \(Entity _ a, b) ->
+            (joinOneName a, maybe "NULL" (joinOtherName . entityVal) b)
 
-    it "doesn't require an on for a crossjoin" $ do
-      void $ run $
-        select $
-        from $ \(a `CrossJoin` b) -> do
-        pure (a :: SqlExpr (Entity JoinOne), b :: SqlExpr (Entity JoinTwo))
+        itDb "doesn't require an on for a crossjoin" $ do
+          void $
+            select $
+            from $ \(a `CrossJoin` b) -> do
+            pure (a :: SqlExpr (Entity JoinOne), b :: SqlExpr (Entity JoinTwo))
+          asserting noExceptions
 
-    it "errors with an on for a crossjoin" $ do
-      (void $ run $
-        select $
-        from $ \(a `CrossJoin` b) -> do
-        on $ a ^. JoinOneId ==. b ^. JoinTwoJoinOne
-        pure (a, b))
-          `shouldThrow` \(OnClauseWithoutMatchingJoinException _) ->
-            True
+        itDb "errors with an on for a crossjoin" $ do
+            eres <-
+              try $
+              select $
+              from $ \(a `CrossJoin` b) -> do
+              on $ a ^. JoinOneId ==. b ^. JoinTwoJoinOne
+              pure (a, b)
+            asserting $
+                case eres of
+                    Left (OnClauseWithoutMatchingJoinException _) ->
+                        pure ()
+                    Right _ ->
+                        expectationFailure "Expected OnClause exception"
 
-    it "left joins associativity" $ do
-      ca <- run $ do
-        setup
-        select $
-          from $ \(a `LeftOuterJoin` (b `InnerJoin` c)) -> do
-          on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
-          on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
-          orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
-          pure (a, c)
-      ca' <- run $ do
-        setup
-        select $
-          from $ \(a `LeftOuterJoin` b `InnerJoin` c) -> do
-          on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
-          on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
-          orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
-          pure (a, c)
+        itDb "left joins associativity" $ do
+          ca <- do
+            setup
+            select $
+              from $ \(a `LeftOuterJoin` (b `InnerJoin` c)) -> do
+              on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
+              on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
+              orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
+              pure (a, c)
+          ca' <- do
+            setup
+            select $
+              from $ \(a `LeftOuterJoin` b `InnerJoin` c) -> do
+              on (c ?. JoinOtherId ==. b ?. JoinManyJoinOther)
+              on (just (a ^. JoinOneId) ==. b ?. JoinManyJoinOne)
+              orderBy [asc $ a ^. JoinOneId, asc $ c ?. JoinOtherId]
+              pure (a, c)
 
-      listsEqualOn ca ca' $ \(Entity _ a, b) ->
-        (joinOneName a, maybe "NULL" (joinOtherName . entityVal) b)
+          asserting $ listsEqualOn ca ca' $ \(Entity _ a, b) ->
+            (joinOneName a, maybe "NULL" (joinOtherName . entityVal) b)
 
-    it "composes queries still" $ do
-      let
-        query1 =
-          from $ \(foo `InnerJoin` bar) -> do
-          on (foo ^. FooId ==. bar ^. BarQuux)
-          pure (foo, bar)
-        query2 =
-          from $ \(p `LeftOuterJoin` bp) -> do
-          on (p ^. PersonId ==. bp ^. BlogPostAuthorId)
-          pure (p, bp)
-      (a, b) <- run $ do
-        fid <- insert $ Foo 5
-        _ <- insert $ Bar fid
-        pid <- insert $ Person "hey" Nothing Nothing 30
-        _ <- insert $ BlogPost "WHY" pid
-        a <- select ((,) <$> query1 <*> query2)
-        b <- select (flip (,) <$> query1 <*> query2)
-        pure (a, b)
-      listsEqualOn a (map (\(x, y) -> (y, x)) b) id
+        itDb "composes queries still" $ do
+            let
+                query1 =
+                    from $ \(foo `InnerJoin` bar) -> do
+                    on (foo ^. FooId ==. bar ^. BarQuux)
+                    pure (foo, bar)
+                query2 =
+                    from $ \(p `LeftOuterJoin` bp) -> do
+                    on (p ^. PersonId ==. bp ^. BlogPostAuthorId)
+                    pure (p, bp)
+            fid <- insert $ Foo 5
+            _ <- insert $ Bar fid
+            pid <- insert $ Person "hey" Nothing Nothing 30
+            _ <- insert $ BlogPost "WHY" pid
+            a <- select ((,) <$> query1 <*> query2)
+            b <- select (flip (,) <$> query1 <*> query2)
+            asserting $ listsEqualOn a (map (\(x, y) -> (y, x)) b) id
 
-    it "works with joins in subselect" $ do
-      run $ void $
-        select $
-        from $ \(p `InnerJoin` r) -> do
-        on $ p ^. PersonId ==. r ^. ReplyGuy
-        pure . (,) (p ^. PersonName) $
-          subSelect $
-          from $ \(c `InnerJoin` bp) -> do
-          on $ bp ^. BlogPostId ==. c ^. CommentBlog
-          pure (c ^. CommentBody)
+        itDb "works with joins in subselect" $ do
+            select $
+                from $ \(p `InnerJoin` r) -> do
+                on $ p ^. PersonId ==. r ^. ReplyGuy
+                pure . (,) (p ^. PersonName) $
+                  subSelect $
+                  from $ \(c `InnerJoin` bp) -> do
+                  on $ bp ^. BlogPostId ==. c ^. CommentBlog
+                  pure (c ^. CommentBody)
+            asserting noExceptions
 
-    describe "works with nested joins" $ do
-      it "unnested" $ do
-        run $ void $
-          selectRethrowingQuery $
-          from $ \(f `InnerJoin` b `LeftOuterJoin` baz `InnerJoin` shoop) -> do
-          on $ f ^. FooId ==. b ^. BarQuux
-          on $ f ^. FooId ==. baz ^. BazBlargh
-          on $ baz ^. BazId ==. shoop ^. ShoopBaz
-          pure ( f ^. FooName)
-      it "leftmost nesting" $ do
-        run $ void $
-          selectRethrowingQuery $
-          from $ \((f `InnerJoin` b) `LeftOuterJoin` baz `InnerJoin` shoop) -> do
-          on $ f ^. FooId ==. b ^. BarQuux
-          on $ f ^. FooId ==. baz ^. BazBlargh
-          on $ baz ^. BazId ==. shoop ^. ShoopBaz
-          pure ( f ^. FooName)
-      describe "middle nesting" $ do
-        it "direct association" $ do
-          run $ void $
-            selectRethrowingQuery $
-            from $ \(p `InnerJoin` (bp `LeftOuterJoin` c) `LeftOuterJoin` cr) -> do
-            on $ p ^. PersonId ==. bp ^. BlogPostAuthorId
-            on $ just (bp ^. BlogPostId) ==. c ?. CommentBlog
-            on $ c ?. CommentId ==. cr ?. CommentReplyComment
-            pure (p,bp,c,cr)
-        it "indirect association" $ do
-          run $ void $
-            selectRethrowingQuery $
-            from $ \(f `InnerJoin` b `LeftOuterJoin` (baz `InnerJoin` shoop) `InnerJoin` asdf) -> do
-            on $ f ^. FooId ==. b ^. BarQuux
-            on $ f ^. FooId ==. baz ^. BazBlargh
-            on $ baz ^. BazId ==. shoop ^. ShoopBaz
-            on $ asdf ^. AsdfShoop ==. shoop ^. ShoopId
-            pure (f ^. FooName)
-        it "indirect association across" $ do
-          run $ void $
-            selectRethrowingQuery $
-            from $ \(f `InnerJoin` b `LeftOuterJoin` (baz `InnerJoin` shoop) `InnerJoin` asdf `InnerJoin` another `InnerJoin` yetAnother) -> do
-            on $ f ^. FooId ==. b ^. BarQuux
-            on $ f ^. FooId ==. baz ^. BazBlargh
-            on $ baz ^. BazId ==. shoop ^. ShoopBaz
-            on $ asdf ^. AsdfShoop ==. shoop ^. ShoopId
-            on $ another ^. AnotherWhy ==. baz ^. BazId
-            on $ yetAnother ^. YetAnotherArgh ==. shoop ^. ShoopId
-            pure (f ^. FooName)
+        describe "works with nested joins" $ do
+          itDb "unnested" $ do
+              selectRethrowingQuery $
+                  from $ \(f `InnerJoin` b `LeftOuterJoin` baz `InnerJoin` shoop) -> do
+                  on $ f ^. FooId ==. b ^. BarQuux
+                  on $ f ^. FooId ==. baz ^. BazBlargh
+                  on $ baz ^. BazId ==. shoop ^. ShoopBaz
+                  pure ( f ^. FooName)
+              asserting noExceptions
 
-      describe "rightmost nesting" $ do
-        it "direct associations" $ do
-          run $ void $
-            selectRethrowingQuery $
-            from $ \(p `InnerJoin` bp `LeftOuterJoin` (c `LeftOuterJoin` cr)) -> do
-            on $ p ^. PersonId ==. bp ^. BlogPostAuthorId
-            on $ just (bp ^. BlogPostId) ==. c ?. CommentBlog
-            on $ c ?. CommentId ==. cr ?. CommentReplyComment
-            pure (p,bp,c,cr)
+          itDb "leftmost nesting" $ do
+              selectRethrowingQuery $
+                  from $ \((f `InnerJoin` b) `LeftOuterJoin` baz `InnerJoin` shoop) -> do
+                  on $ f ^. FooId ==. b ^. BarQuux
+                  on $ f ^. FooId ==. baz ^. BazBlargh
+                  on $ baz ^. BazId ==. shoop ^. ShoopBaz
+                  pure ( f ^. FooName)
+              asserting noExceptions
+          describe "middle nesting" $ do
+            itDb "direct association" $ do
+                selectRethrowingQuery $
+                    from $ \(p `InnerJoin` (bp `LeftOuterJoin` c) `LeftOuterJoin` cr) -> do
+                    on $ p ^. PersonId ==. bp ^. BlogPostAuthorId
+                    on $ just (bp ^. BlogPostId) ==. c ?. CommentBlog
+                    on $ c ?. CommentId ==. cr ?. CommentReplyComment
+                    pure (p,bp,c,cr)
+                asserting noExceptions
+            itDb "indirect association" $ do
+                selectRethrowingQuery $
+                    from $ \(f `InnerJoin` b `LeftOuterJoin` (baz `InnerJoin` shoop) `InnerJoin` asdf) -> do
+                    on $ f ^. FooId ==. b ^. BarQuux
+                    on $ f ^. FooId ==. baz ^. BazBlargh
+                    on $ baz ^. BazId ==. shoop ^. ShoopBaz
+                    on $ asdf ^. AsdfShoop ==. shoop ^. ShoopId
+                    pure (f ^. FooName)
+                asserting noExceptions
+            itDb "indirect association across" $ do
+                selectRethrowingQuery $
+                    from $ \(f `InnerJoin` b `LeftOuterJoin` (baz `InnerJoin` shoop) `InnerJoin` asdf `InnerJoin` another `InnerJoin` yetAnother) -> do
+                    on $ f ^. FooId ==. b ^. BarQuux
+                    on $ f ^. FooId ==. baz ^. BazBlargh
+                    on $ baz ^. BazId ==. shoop ^. ShoopBaz
+                    on $ asdf ^. AsdfShoop ==. shoop ^. ShoopId
+                    on $ another ^. AnotherWhy ==. baz ^. BazId
+                    on $ yetAnother ^. YetAnotherArgh ==. shoop ^. ShoopId
+                    pure (f ^. FooName)
+                asserting noExceptions
 
-        it "indirect association" $ do
-          run $ void $
-            selectRethrowingQuery $
-            from $ \(f `InnerJoin` b `LeftOuterJoin` (baz `InnerJoin` shoop)) -> do
-            on $ f ^. FooId ==. b ^. BarQuux
-            on $ f ^. FooId ==. baz ^. BazBlargh
-            on $ baz ^. BazId ==. shoop ^. ShoopBaz
-            pure (f ^. FooName)
+          describe "rightmost nesting" $ do
+            itDb "direct associations" $ do
+                selectRethrowingQuery $
+                    from $ \(p `InnerJoin` bp `LeftOuterJoin` (c `LeftOuterJoin` cr)) -> do
+                    on $ p ^. PersonId ==. bp ^. BlogPostAuthorId
+                    on $ just (bp ^. BlogPostId) ==. c ?. CommentBlog
+                    on $ c ?. CommentId ==. cr ?. CommentReplyComment
+                    pure (p,bp,c,cr)
+                asserting noExceptions
 
-testExperimentalFrom :: Run -> Spec
-testExperimentalFrom run = do
+            itDb "indirect association" $ do
+                selectRethrowingQuery $
+                    from $ \(f `InnerJoin` b `LeftOuterJoin` (baz `InnerJoin` shoop)) -> do
+                    on $ f ^. FooId ==. b ^. BarQuux
+                    on $ f ^. FooId ==. baz ^. BazBlargh
+                    on $ baz ^. BazId ==. shoop ^. ShoopBaz
+                    pure (f ^. FooName)
+                asserting noExceptions
+
+testExperimentalFrom :: SpecDb
+testExperimentalFrom = do
   describe "Experimental From" $ do
-    it "supports basic table queries" $ do
-      run $ do
+    itDb "supports basic table queries" $ do
         p1e <- insert' p1
         _   <- insert' p2
         p3e <- insert' p3
@@ -2189,10 +2194,9 @@ testExperimentalFrom run = do
           people <- Experimental.from $ Table @Person
           where_ $ not_ $ isNothing $ people ^. PersonAge
           return people
-        liftIO $ peopleWithAges `shouldMatchList` [p1e, p3e]
+        asserting $ peopleWithAges `shouldMatchList` [p1e, p3e]
 
-    it "supports inner joins" $ do
-      run $ do
+    itDb "supports inner joins" $ do
         l1e <- insert' l1
         _   <- insert  l2
         d1e <- insert' $ Deed "1" (entityKey l1e)
@@ -2203,12 +2207,11 @@ testExperimentalFrom run = do
                     `InnerJoin` Table @Deed
               `Experimental.on` (\(l :& d) -> l ^. LordId ==. d ^. DeedOwnerId)
           pure (lords, deeds)
-        liftIO $ lordDeeds `shouldMatchList` [ (l1e, d1e)
+        asserting $ lordDeeds `shouldMatchList` [ (l1e, d1e)
                                              , (l1e, d2e)
                                              ]
 
-    it "supports outer joins" $ do
-      run $ do
+    itDb "supports outer joins" $ do
         l1e <- insert' l1
         l2e <- insert' l2
         d1e <- insert' $ Deed "1" (entityKey l1e)
@@ -2220,21 +2223,19 @@ testExperimentalFrom run = do
                   `Experimental.on` (\(l :& d) -> just (l ^. LordId) ==. d ?. DeedOwnerId)
 
           pure (lords, deeds)
-        liftIO $ lordDeeds `shouldMatchList` [ (l1e, Just d1e)
+        asserting $ lordDeeds `shouldMatchList` [ (l1e, Just d1e)
                                              , (l1e, Just d2e)
                                              , (l2e, Nothing)
                                              ]
-    it "supports delete" $ do
-      run $ do
+    itDb "supports delete" $ do
         insert_ l1
         insert_ l2
         insert_ l3
         delete $ void $ Experimental.from $ Table @Lord
         lords <- select $ Experimental.from $ Table @Lord
-        liftIO $ lords `shouldMatchList` []
+        asserting $ lords `shouldMatchList` []
 
-    it "supports implicit cross joins" $ do
-      run $ do
+    itDb "supports implicit cross joins" $ do
         l1e <- insert' l1
         l2e <- insert' l2
         ret <- select $ do
@@ -2244,16 +2245,15 @@ testExperimentalFrom run = do
         ret2 <- select $ do
           (lords1 :& lords2) <- Experimental.from $ Table @Lord `CrossJoin` Table @Lord
           pure (lords1,lords2)
-        liftIO $ ret `shouldMatchList` ret2
-        liftIO $ ret `shouldMatchList` [ (l1e, l1e)
+        asserting $ ret `shouldMatchList` ret2
+        asserting $ ret `shouldMatchList` [ (l1e, l1e)
                                        , (l1e, l2e)
                                        , (l2e, l1e)
                                        , (l2e, l2e)
                                        ]
 
 
-    it "compiles" $ do
-      run $ void $ do
+    itDb "compiles" $ do
         let q = do
               (persons :& profiles :& posts) <-
                 Experimental.from $  Table @Person
@@ -2264,11 +2264,9 @@ testExperimentalFrom run = do
                    `Experimental.on` (\(people :& _ :& posts) ->
                                         just (people ^. PersonId) ==. posts ?. BlogPostAuthorId)
               pure (persons, posts, profiles)
-        --error . show =<< renderQuerySelect q
-        pure ()
+        asserting noExceptions
 
-    it "can call functions on aliased values" $ do
-      run $ do
+    itDb "can call functions on aliased values" $ do
         insert_ p1
         insert_ p3
         -- Pretend this isnt all posts
@@ -2276,38 +2274,38 @@ testExperimentalFrom run = do
           author <- Experimental.from $ SelectQuery $ Experimental.from $ Table @Person
           pure $ upper_ $ author ^. PersonName
 
-        liftIO $ upperNames `shouldMatchList` [ Value "JOHN"
+        asserting $ upperNames `shouldMatchList` [ Value "JOHN"
                                               , Value "MIKE"
                                               ]
 
 listsEqualOn :: (Show a1, Eq a1) => [a2] -> [a2] -> (a2 -> a1) -> Expectation
 listsEqualOn a b f = map f a `shouldBe` map f b
 
-tests :: Run -> Spec
-tests run = do
+tests :: SpecDb
+tests = do
     describe "Esqueleto" $ do
-        testSelect run
-        testSubSelect run
-        testSelectSource run
-        testSelectFrom run
-        testSelectJoin run
-        testSelectSubQuery run
-        testSelectWhere run
-        testSelectOrderBy run
-        testSelectDistinct run
-        testCoasleceDefault run
-        testDelete run
-        testUpdate run
-        testListOfValues run
-        testListFields run
-        testInsertsBySelect run
-        testMathFunctions run
-        testCase run
-        testCountingRows run
-        testRenderSql run
-        testOnClauseOrder run
-        testExperimentalFrom run
-
+        testSelect
+        testSubSelect
+        testSelectSource
+        testSelectFrom
+        testSelectJoin
+        testSelectSubQuery
+        testSelectWhere
+        testSelectOrderBy
+        testSelectDistinct
+        testCoasleceDefault
+        testDelete
+        testUpdate
+        testListOfValues
+        testListFields
+        testInsertsBySelect
+        testMathFunctions
+        testCase
+        testCountingRows
+        testRenderSql
+        testOnClauseOrder
+        testExperimentalFrom
+        testLocking
 
 insert' :: ( Functor m
            , BaseBackend backend ~ PersistEntityBackend val
@@ -2391,3 +2389,15 @@ updateRethrowingQuery k =
         `catch` \(SomeException e) -> do
             (text, _) <- renderQueryUpdate (from k)
             liftIO . throwIO . userError $ Text.unpack text <> "\n\n" <> show e
+
+shouldBeOnClauseWithoutMatchingJoinException
+    :: (HasCallStack, Show a)
+    => Either SomeException a
+    -> Expectation
+shouldBeOnClauseWithoutMatchingJoinException ea =
+    case ea of
+        Left (fromException -> Just OnClauseWithoutMatchingJoinException {}) ->
+            pure ()
+        _ ->
+            expectationFailure $ "Expected OnClauseWithMatchingJoinException, got: " <> show ea
+

--- a/test/Common/Test/Import.hs
+++ b/test/Common/Test/Import.hs
@@ -81,3 +81,13 @@ testDb conn action =
         a <- action
         transactionUndo
         pure a
+
+setDatabaseState
+    :: SqlPersistT IO a
+    -> SqlPersistT IO ()
+    -> SpecWith ConnectionPool
+    -> SpecWith ConnectionPool
+setDatabaseState create clean test =
+    beforeWith (\conn -> runSqlPool create conn >> pure conn) $
+    after (\conn -> runSqlPool clean conn) $
+    test

--- a/test/Common/Test/Select.hs
+++ b/test/Common/Test/Select.hs
@@ -2,25 +2,21 @@ module Common.Test.Select where
 
 import Common.Test.Import
 
-testSelect :: Run -> Spec
-testSelect run = do
+testSelect :: SpecDb
+testSelect = do
     describe "select" $ do
-        it "works for a single value" $
-            run $ do
-                ret <- select $ return $ val (3 :: Int)
-                liftIO $ ret `shouldBe` [ Value 3 ]
+        itDb "works for a single value" $ do
+            ret <- select $ return $ val (3 :: Int)
+            asserting $ ret `shouldBe` [ Value 3 ]
 
-        it "works for a pair of a single value and ()" $
-            run $ do
-                ret <- select $ return (val (3 :: Int), ())
-                liftIO $ ret `shouldBe` [ (Value 3, ()) ]
+        itDb "works for a pair of a single value and ()" $ do
+            ret <- select $ return (val (3 :: Int), ())
+            asserting $ ret `shouldBe` [ (Value 3, ()) ]
 
-        it "works for a single ()" $
-            run $ do
-                ret <- select $ return ()
-                liftIO $ ret `shouldBe` [ () ]
+        itDb "works for a single ()" $ do
+            ret <- select $ return ()
+            asserting $ ret `shouldBe` [ () ]
 
-        it "works for a single NULL value" $
-            run $ do
-                ret <- select $ return nothing
-                liftIO $ ret `shouldBe` [ Value (Nothing :: Maybe Int) ]
+        itDb "works for a single NULL value" $ do
+            ret <- select $ return nothing
+            asserting $ ret `shouldBe` [ Value (Nothing :: Maybe Int) ]

--- a/test/MySQL/Test.hs
+++ b/test/MySQL/Test.hs
@@ -195,13 +195,10 @@ testMysqlUnionWithLimits = do
         liftIO $ ret `shouldMatchList` [Value 1, Value 2, Value 4, Value 5]
 
 spec :: Spec
-spec = do
-    tests run
+spec = beforeAll undefined $ do
+    tests
 
-    describe "Test MySQL locking" $ do
-        testLocking withConn
-
-    describe "MySQL specific tests" $ do
+    beforeWith (\_ -> pure ()) $ describe "MySQL specific tests" $ do
         -- definitely doesn't work at the moment
         -- testMysqlRandom
         testMysqlSum
@@ -263,4 +260,3 @@ isCI =  do
     return $ case lookup "TRAVIS" env <|> lookup "CI" env of
         Just "true" -> True
         _ -> False
-

--- a/test/PostgreSQL/MigrateJSON.hs
+++ b/test/PostgreSQL/MigrateJSON.hs
@@ -16,6 +16,8 @@
 
 module PostgreSQL.MigrateJSON where
 
+import Common.Test.Import hiding (Value, from, on)
+
 import Control.Monad.Trans.Resource (ResourceT)
 import Data.Aeson (Value)
 import Database.Esqueleto (SqlExpr, delete, from)
@@ -34,6 +36,6 @@ Json
 |]
 
 cleanJSON
-  :: (forall m. RunDbMonad m
-  => SqlPersistT (ResourceT m) ())
+    :: forall m. MonadIO m
+    => SqlPersistT m ()
 cleanJSON = delete $ from $ \(_ :: SqlExpr (Entity Json)) -> return ()

--- a/test/PostgreSQL/MigrateJSON.hs
+++ b/test/PostgreSQL/MigrateJSON.hs
@@ -18,15 +18,10 @@ module PostgreSQL.MigrateJSON where
 
 import Common.Test.Import hiding (Value, from, on)
 
-import Control.Monad.Trans.Resource (ResourceT)
 import Data.Aeson (Value)
-import Database.Esqueleto (SqlExpr, delete, from)
+import Database.Esqueleto.Legacy (from)
 import Database.Esqueleto.PostgreSQL.JSON (JSONB)
-import Database.Persist (Entity)
-import Database.Persist.Sql (SqlPersistT)
 import Database.Persist.TH
-
-import Common.Test (RunDbMonad)
 
 -- JSON Table for PostgreSQL
 share [mkPersist sqlSettings, mkMigrate "migrateJSON"] [persistUpperCase|

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1385,10 +1385,13 @@ run_worker act = withConn $ runSqlConn (migrateIt >> act)
 
 migrateIt :: _ => SqlPersistT m ()
 migrateIt = mapReaderT runNoLoggingT $ do
-    void $ runMigrationSilent migrateAll
-    void $ runMigrationSilent migrateUnique
+    void $ runMigrationSilent $ do
+        migrateAll
+        migrateUnique
+        migrateJSON
     cleanDB
     cleanUniques
+    cleanJSON
 
 withConn :: RunDbMonad m => (SqlBackend -> R.ResourceT m a) -> m a
 withConn f = do

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1396,14 +1396,11 @@ selectJSON f = select $ from $ \v -> do
 
 spec :: Spec
 spec = do
-    tests run
-
-    describe "Test PostgreSQL locking" $ do
-        testLocking withConn
+    beforeAll (undefined :: IO ConnectionPool) tests
 
     describe "PostgreSQL specific tests" $ do
-        testAscRandom random_ run
-        testRandomMath run
+        testAscRandom random_
+        testRandomMath
         testSelectDistinctOn
         testPostgresModule
         testPostgresqlOneAscOneDesc

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -533,25 +533,22 @@ testPostgresModule = do
 
 testJSONInsertions :: SpecDb
 testJSONInsertions =
-  describe "JSON Insertions" $ do
-    itDb "adds scalar values" $ do
-       do
-        insertIt Null
-        insertIt $ Bool True
-        insertIt $ Number 1
-        insertIt $ String "test"
-    itDb "adds arrays" $ do
-       do
-        insertIt $ toJSON ([] :: [A.Value])
-        insertIt $ toJSON [Number 1, Bool True, Null]
-        insertIt $ toJSON [String "test",object ["a" .= Number 3.14], Null, Bool True]
-    itDb "adds objects" $ do
-       do
-        insertIt $ object ["a" .= (1 :: Int), "b" .= False]
-        insertIt $ object ["a" .= object ["b" .= object ["c" .= String "message"]]]
-  where insertIt :: MonadIO m => A.Value -> SqlPersistT m ()
-        insertIt = insert_ . Json . JSONB
-
+    describe "JSON Insertions" $ do
+        itDb "adds scalar values" $ do
+            insertIt Null
+            insertIt $ Bool True
+            insertIt $ Number 1
+            insertIt $ String "test"
+        itDb "adds arrays" $ do
+            insertIt $ toJSON ([] :: [A.Value])
+            insertIt $ toJSON [Number 1, Bool True, Null]
+            insertIt $ toJSON [String "test",object ["a" .= Number 3.14], Null, Bool True]
+        itDb "adds objects" $ do
+            insertIt $ object ["a" .= (1 :: Int), "b" .= False]
+            insertIt $ object ["a" .= object ["b" .= object ["c" .= String "message"]]]
+  where
+    insertIt :: MonadIO m => A.Value -> SqlPersistT m ()
+    insertIt = insert_ . Json . JSONB
 
 testJSONOperators :: SpecDb
 testJSONOperators =
@@ -675,11 +672,11 @@ testHashArrowText =
 
 testFilterOperators :: SpecDb
 testFilterOperators =
-  describe "Filter Operators" $ do
-    testInclusion
-    testQMark
-    testQMarkAny
-    testQMarkAll
+    describe "Filter Operators" $ do
+        testInclusion
+        testQMark
+        testQMarkAny
+        testQMarkAll
 
 testInclusion :: SpecDb
 testInclusion = do
@@ -1354,15 +1351,34 @@ spec = beforeAll mkConnectionPool $ do
         testInsertSelectWithConflict
         testFilterWhere
         testCommonTableExpressions
-        describe "PostgreSQL JSON tests" $ do
-            -- NOTE: We only clean the table once, so we
-            -- can use its contents across all JSON tests
-            itDb "MIGRATE AND CLEAN JSON TABLE" $  do
-                void $ runMigrationSilent migrateJSON
-                cleanJSON
-            testJSONInsertions
-            testJSONOperators
+        beforeWith insertJsonValues
+            $ after deleteJsonValues
+            $ describe "PostgreSQL JSON tests" $ do
+                testJSONInsertions
+                testJSONOperators
         testLateralQuery
+
+insertJsonValues :: ConnectionPool -> IO ConnectionPool
+insertJsonValues conn = do
+    flip runSqlPool conn $  do
+        insertIt Null
+        insertIt $ Bool True
+        insertIt $ Number 1
+        insertIt $ String "test"
+        insertIt $ toJSON ([] :: [A.Value])
+        insertIt $ toJSON [Number 1, Bool True, Null]
+        insertIt $ toJSON [String "test",object ["a" .= Number 3.14], Null, Bool True]
+        insertIt $ object ["a" .= (1 :: Int), "b" .= False]
+        insertIt $ object ["a" .= object ["b" .= object ["c" .= String "message"]]]
+    pure conn
+  where
+    insertIt :: MonadIO m => A.Value -> SqlPersistT m ()
+    insertIt = insert_ . Json . JSONB
+
+deleteJsonValues :: ActionWith ConnectionPool
+deleteJsonValues conn = do
+    flip runSqlPool conn $
+        cleanJSON
 
 run, runSilent, runVerbose :: Run
 runSilent  act = runNoLoggingT     $ run_worker act
@@ -1391,7 +1407,6 @@ migrateIt = mapReaderT runNoLoggingT $ do
         migrateJSON
     cleanDB
     cleanUniques
-    cleanJSON
 
 withConn :: RunDbMonad m => (SqlBackend -> R.ResourceT m a) -> m a
 withConn f = do


### PR DESCRIPTION
This PR inverts control in the test suite. Instead of having each test suite provide a `run` function which runs the database action, the test suite expects a `ConnectionPool` to be made available to it. Then the various backends use `beforeAll :: IO ConnectionPool -> SpecWith ConnectionPool -> Spec` to make it happen.

A further advantage is that we'll be able to use `beforeWith :: (ConnectionPool -> IO ConnectionPool) -> SpecWith ConnectionPool -> SpecWith ConnectionPool` to implement things like, y'know, inserting test/setup data into the database, and `afterWith` to clean it up.

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
