### PR TITLE
Avoid generating an empty list as the left operand to NOT IN

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.2.1
+=======
+- @cdparks
+  - [#273](https://github.com/bitemyapp/esqueleto/pull/273)
+        - Avoid generating an empty list as the left operand to `NOT IN`.
+
 3.5.2.0
 =======
 - @ivanbakel

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.5.2.0
+version:        3.5.2.1
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -939,7 +939,11 @@ notIn :: PersistField typ => SqlExpr (Value typ) -> SqlExpr (ValueList typ) -> S
     ERaw noMeta $ \_ info ->
         let (b1, vals1) = v Parens info
             (b2, vals2) = list Parens info
-        in (b1 <> " NOT IN " <> b2, vals1 <> vals2)
+        in
+        if b2 == "()" then
+            ("TRUE", [])
+        else
+            (b1 <> " NOT IN " <> b2, vals1 <> vals2)
 
 -- | @EXISTS@ operator.  For example:
 --

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1431,6 +1431,19 @@ testListOfValues = describe "lists of values" $ do
                return p
         asserting $ ret `shouldBe` [ Entity p2k p2 ]
 
+    itDb "NOT IN works for valList (null list)" $ do
+        p1k <- insert p1
+        p2k <- insert p2
+        p3k <- insert p3
+        ret <- select $
+               from $ \p -> do
+               where_ (p ^. PersonName `notIn` valList [])
+               return p
+        asserting $ ret `shouldMatchList` [ Entity p1k p1
+                                          , Entity p2k p2
+                                          , Entity p3k p3
+                                          ]
+
     itDb "EXISTS works for subList_select" $ do
         p1k <- insert p1
         _p2k <- insert p2


### PR DESCRIPTION
Postgres treats `x in ()` and `x not in ()` as syntax errors. Instead translate:

```plaintext
  x in ()      ⇒  FALSE
  x not in ()  ⇒  TRUE
```

Older versions of esqueleto did both of these, but apparently the latter got lost in the most recent version. See issue #272.

Before submitting your PR, check that you've:

- [x] Bumped the version number. ~~**I'm not sure what the version number should be, looks like esqueleto uses PVP?**~~ I bumped the smallest component to `3.5.2.1` since this is a bugfix
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html). **N/A**
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock. **N/A**
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).