### PR TITLE
Fix distinctOnOrderBy with nested expression

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.2.2
+=======
+- @NikitaRazmakhnin
+  - [#278](https://github.com/bitemyapp/esqueleto/pull/278)
+        - Fix generating of bad sql using nexted expressions with `distinctOnOrderBy`.
+
 3.5.2.1
 =======
 - @cdparks

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.5.2.1
+version:        3.5.2.2
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -374,7 +374,11 @@ distinctOnOrderBy exprs act =
     toDistinctOn :: SqlExpr OrderBy -> SqlExpr DistinctOn
     toDistinctOn (ERaw m f) = ERaw m $ \p info ->
         let (b, vals) = f p info
-        in (TLB.fromLazyText $ head $ TL.splitOn " " $ TLB.toLazyText b, vals)
+        in  ( TLB.fromLazyText
+              $ TL.replace " DESC" ""
+              $ TL.replace " ASC" ""
+              $ TLB.toLazyText b
+            , vals )
 
 -- | @ORDER BY random()@ clause.
 --

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -220,6 +220,12 @@ testSelectDistinctOn = do
       slightlyLessSimpleTest $ \bp ->
         distinctOnOrderBy [asc (bp ^. BlogPostAuthorId), asc (bp ^. BlogPostTitle)]
 
+    itDb "generates correct sql with nested expression (distinctOnOrderBy)" $ do
+      let query = do
+            let orderVal = coalesce [nothing, just $ val (10 :: Int)]
+            distinctOnOrderBy [ asc orderVal, desc orderVal ] $ pure orderVal
+      select query
+      asserting noExceptions
 
 
 


### PR DESCRIPTION
Should solve https://github.com/bitemyapp/esqueleto/issues/277.
Code assembling `DISTINCT ON` clause was stripping important part of important nested expressions. It worked well without nested expressions but with them it just cuts by spaces parts with arguments. So for example with `COALESCE(val, ?) ASC` it splits assembled expression into `["COALESCE(val,", "?)", "ASC"]` which causes bad sql for some cases.

I am not sure it is a good solution because I actually don't know is it possible to have other expressions here or not? Please, let me know if you see any other possible issues with that fix. :)

A related test-case is added.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
