### PR TITLE
Add missing instances to (:&)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+3.5.3.0
+- @m4dc4p
+  - [#291](https://github.com/bitemyapp/esqueleto/pull/291)
+         - Added `ToAlias` and `ToAliasReference` instaces to the `:&` type, mirroring
+         the tuple instances for the same classes. See [Issue #290](https://github.com/bitemyapp/esqueleto/issues/290)
+         for discussion.
+         
 3.5.2.2
 =======
 - @NikitaRazmakhnin

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.5.2.2
+version:        3.5.2.3
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.5.2.3
+version:        3.5.3.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental/From/Join.hs
+++ b/src/Database/Esqueleto/Experimental/From/Join.hs
@@ -61,6 +61,18 @@ instance (SqlSelect a ra, SqlSelect b rb) => SqlSelect (a :& b) (ra :& rb) where
         toTuple = const Proxy
     sqlSelectProcessRow = fmap (uncurry (:&)) . sqlSelectProcessRow
 
+-- | Identical to the tuple instance and provided for convenience.
+--
+-- @since 3.5.2.3
+instance (ToAlias a, ToAlias b) => ToAlias (a :& b) where
+    toAlias (a :& b) = (:&) <$> toAlias a <*> toAlias b
+
+-- | Identical to the tuple instance and provided for convenience.
+--
+-- @since 3.5.2.3
+instance (ToAliasReference a, ToAliasReference b) => ToAliasReference (a :& b) where
+    toAliasReference ident (a :& b) = (:&) <$> (toAliasReference ident a) <*> (toAliasReference ident b)
+
 -- | An @ON@ clause that describes how two tables are related. This should be
 -- used as an infix operator after a 'JOIN'. For example,
 --

--- a/src/Database/Esqueleto/Experimental/From/Join.hs
+++ b/src/Database/Esqueleto/Experimental/From/Join.hs
@@ -63,13 +63,13 @@ instance (SqlSelect a ra, SqlSelect b rb) => SqlSelect (a :& b) (ra :& rb) where
 
 -- | Identical to the tuple instance and provided for convenience.
 --
--- @since 3.5.2.3
+-- @since 3.5.3.0
 instance (ToAlias a, ToAlias b) => ToAlias (a :& b) where
     toAlias (a :& b) = (:&) <$> toAlias a <*> toAlias b
 
 -- | Identical to the tuple instance and provided for convenience.
 --
--- @since 3.5.2.3
+-- @since 3.5.3.0
 instance (ToAliasReference a, ToAliasReference b) => ToAliasReference (a :& b) where
     toAliasReference ident (a :& b) = (:&) <$> (toAliasReference ident a) <*> (toAliasReference ident b)
 

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -2316,7 +2316,7 @@ testExperimentalFrom = do
       let result = coerce rows :: [(PersonId, ProfileId, BlogPostId)]
       -- We don't care about eh result of the query, only that it
       -- rendered & executed.
-      asserting (null $ drop 1000 result)
+      asserting noExceptions
 
 listsEqualOn :: (HasCallStack, Show a1, Eq a1) => [a2] -> [a2] -> (a2 -> a1) -> Expectation
 listsEqualOn a b f = map f a `shouldBe` map f b

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -2313,7 +2313,7 @@ testExperimentalFrom = do
       rows <- select $ do
         (persons :& profiles :& posts) <- Experimental.from $ q
         pure (persons ^. PersonId, profiles ^. ProfileId, posts ^. BlogPostId)
-      let result :: [(PersonId, ProfileId, BlogPostId)] = [(a, b, c) | (Value a, Value b, Value c) <- rows]
+      let result = coerce rows :: [(PersonId, ProfileId, BlogPostId)]
       -- We don't care about eh result of the query, only that it
       -- rendered & executed.
       asserting (null $ drop 1000 result)

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -2308,7 +2308,7 @@ testExperimentalFrom = do
                                         people ^. PersonId ==. profiles ^. ProfilePerson)
                      `InnerJoin` Table @BlogPost
                    `Experimental.on` (\(people :& _ :& posts) ->
-                                        (people ^. PersonId) ==. posts ^. BlogPostAuthorId)
+                                        people ^. PersonId ==. posts ^. BlogPostAuthorId)
               pure result
       rows <- select $ do
         (persons :& profiles :& posts) <- Experimental.from $ q

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -2275,7 +2275,6 @@ testExperimentalFrom = do
                                        , (l2e, l2e)
                                        ]
 
-
     itDb "compiles" $ do
         let q = do
               (persons :& profiles :& posts) <-
@@ -2300,6 +2299,24 @@ testExperimentalFrom = do
         asserting $ upperNames `shouldMatchList` [ Value "JOHN"
                                               , Value "MIKE"
                                               ]
+    itDb "allows re-using (:&) joined tables" $ do
+      let q = do
+              result@(persons :& profiles :& posts) <-
+                Experimental.from $  Table @Person
+                         `InnerJoin` Table @Profile
+                   `Experimental.on` (\(people :& profiles) ->
+                                        people ^. PersonId ==. profiles ^. ProfilePerson)
+                     `InnerJoin` Table @BlogPost
+                   `Experimental.on` (\(people :& _ :& posts) ->
+                                        (people ^. PersonId) ==. posts ^. BlogPostAuthorId)
+              pure result
+      rows <- select $ do
+        (persons :& profiles :& posts) <- Experimental.from $ q
+        pure (persons ^. PersonId, profiles ^. ProfileId, posts ^. BlogPostId)
+      let result :: [(PersonId, ProfileId, BlogPostId)] = [(a, b, c) | (Value a, Value b, Value c) <- rows]
+      -- We don't care about eh result of the query, only that it
+      -- rendered & executed.
+      asserting (null $ drop 1000 result)
 
 listsEqualOn :: (HasCallStack, Show a1, Eq a1) => [a2] -> [a2] -> (a2 -> a1) -> Expectation
 listsEqualOn a b f = map f a `shouldBe` map f b


### PR DESCRIPTION
The (:&) operator has an instance for `SqlSelect`, but none
for `ToAlias` and `ToAliasReference`. Adding those for parity.

I'm not sure if the should be a patch or major version bump. Adding new instances can break existing code, but they are such small instances ... I guessed and bumped the patch number.

I was unable to get the testing environment working locally, so I was going to rely on CI to execute my tests.  🤞 

Related to #290.

- [x] Bumped the version number.
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
