### PR TITLE
Add @localhost to last MySQL command

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,5 +488,5 @@ user which can access it:
 mysql> CREATE DATABASE esqutest;
 mysql> CREATE USER 'travis'@'localhost';
 mysql> ALTER USER 'travis'@'localhost' IDENTIFIED BY 'esqutest';
-mysql> GRANT ALL ON esqutest.* TO 'travis';
+mysql> GRANT ALL ON esqutest.* TO 'travis'@'localhost';
 ```


### PR DESCRIPTION
It's been a long time since I remembered MySQL user naming convention stuff, but, just empirically I get the following error following the README instructions:

```
mysql -u root
```

```
mysql> GRANT ALL ON esqutest.* TO 'travis';
ERROR 1410 (42000): You are not allowed to create a user with GRANT
mysql> GRANT ALL ON esqutest.* TO 'travis'@'localhost';
Query OK, 0 rows affected (0.00 sec)
```

MySQL version:

```
~/D/C/H/esqueleto> mysql --version                                                                                                                                                                                                                                                                                                                                  12:38:37
mysql  Ver 8.0.22 for osx10.15 on x86_64 (Homebrew)
```
