### PR TITLE
Support OverloadedRecordDot

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+3.5.4.0
+=======
+- @parsonsmatt
+    - []()
+        - Add instances of `HasField` for `SqlExpr (Entity rec)` and `SqlExpr
+          (Maybe (Entity rec))`. These instances allow you to use the
+          `OverloadedRecordDot` language extension in GHC 9.2 with SQL
+          representations of database entities.
+
 3.5.3.2
 =======
 - @parsonsmatt

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.5.3.2
+version:        3.5.4.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeApplications #-}
 {-# language DerivingStrategies, GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -61,7 +62,7 @@ import Database.Esqueleto.Internal.ExprParser (TableAccess(..), parseOnExpr)
 import Database.Esqueleto.Internal.PersistentImport
 import Database.Persist.SqlBackend
 import qualified Database.Persist
-import Database.Persist (FieldNameDB(..), EntityNameDB(..))
+import Database.Persist (FieldNameDB(..), EntityNameDB(..), SymbolToField(..))
 import Database.Persist.Sql.Util
        ( entityColumnCount
        , keyAndEntityColumnNames
@@ -71,6 +72,7 @@ import Database.Persist.Sql.Util
 import Text.Blaze.Html (Html)
 import Data.Coerce (coerce)
 import Data.Kind (Type)
+import GHC.Records
 
 -- | (Internal) Start a 'from' query with an entity. 'from'
 -- does two kinds of magic using 'fromStart', 'fromJoin' and
@@ -2085,6 +2087,13 @@ entityAsValueMaybe = coerce
 -- string ('TLB.Builder') and a list of values to be
 -- interpolated by the SQL backend.
 data SqlExpr a = ERaw SqlExprMeta (NeedParens -> IdentInfo -> (TLB.Builder, [PersistValue]))
+
+instance (PersistEntity rec, PersistField typ, SymbolToField sym rec typ) => HasField sym (SqlExpr (Entity rec)) (SqlExpr (Value typ)) where
+    getField expr = expr ^. symbolToField @sym
+
+instance (PersistEntity rec, PersistField typ, SymbolToField sym rec typ)
+    => HasField sym (SqlExpr (Maybe (Entity rec))) (SqlExpr (Value (Maybe typ))) where
+    getField expr = expr ?. symbolToField @sym
 
 -- | Data type to support from hack
 data PreprocessedFrom a = PreprocessedFrom a FromClause


### PR DESCRIPTION
This PR adds support for `OverloadedRecordDot` on `SqlExpr` values, deferring to the `PersistEntity` and `SymbolToField` machinery described in `persistent`.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
