### PR TITLE
Remove alias that has problems with Simplified Subsumption

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 3.5.4.2
 =======
 - @parsonsmatt
-    - [#]()
-        - Remove use of `SqlReadT` type alias so that Simplified Subsumption
-          doesn't bite
+    - [#318](https://github.com/bitemyapp/esqueleto/pull/318)
+        - Remove use of `SqlReadT` and `SqlWriteT` type alias so that Simplified
+          Subsumption doesn't bite end users
 
 3.5.4.1
 =======

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+3.5.4.2
+=======
+- @parsonsmatt
+    - [#]()
+        - Remove use of `SqlReadT` type alias so that Simplified Subsumption
+          doesn't bite
+
 3.5.4.1
 =======
 - @parsonsmatt

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-version:        3.5.4.1
+version:        3.5.4.2
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -2713,16 +2713,16 @@ rawEsqueleto mode query = do
 -- @
 --
 delete
-    :: (MonadIO m)
+    :: (MonadIO m, SqlBackendCanWrite backend)
     => SqlQuery ()
-    -> SqlWriteT m ()
+    -> R.ReaderT backend m ()
 delete a = void $ deleteCount a
 
 -- | Same as 'delete', but returns the number of rows affected.
 deleteCount
-    :: (MonadIO m)
+    :: (MonadIO m, SqlBackendCanWrite backend)
     => SqlQuery ()
-    -> SqlWriteT m Int64
+    -> R.ReaderT backend m Int64
 deleteCount a = rawEsqueleto DELETE a
 
 -- | Execute an @esqueleto@ @UPDATE@ query inside @persistent@'s
@@ -2741,9 +2741,10 @@ update
     ::
     ( MonadIO m, PersistEntity val
     , BackendCompatible SqlBackend (PersistEntityBackend val)
+    , SqlBackendCanWrite backend
     )
     => (SqlExpr (Entity val) -> SqlQuery ())
-    -> SqlWriteT m ()
+    -> R.ReaderT backend m ()
 update a = void $ updateCount a
 
 -- | Same as 'update', but returns the number of rows affected.
@@ -2751,9 +2752,10 @@ updateCount
     ::
     ( MonadIO m, PersistEntity val
     , BackendCompatible SqlBackend (PersistEntityBackend val)
+    , SqlBackendCanWrite backend
     )
     => (SqlExpr (Entity val) -> SqlQuery ())
-    -> SqlWriteT m Int64
+    -> R.ReaderT backend m Int64
 updateCount a = rawEsqueleto UPDATE $ from a
 
 builderToText :: TLB.Builder -> T.Text
@@ -3691,16 +3693,16 @@ to16 ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),(o,p)) = (a,b,c,d,e,f,g,h,i,j,k,
 --
 -- @since 2.4.2
 insertSelect
-    :: (MonadIO m, PersistEntity a)
+    :: (MonadIO m, PersistEntity a, SqlBackendCanWrite backend)
     => SqlQuery (SqlExpr (Insertion a))
-    -> SqlWriteT m ()
+    -> R.ReaderT backend m ()
 insertSelect a = void $ insertSelectCount a
 
 -- | Insert a 'PersistField' for every selected value, return the count afterward
 insertSelectCount
-    :: (MonadIO m, PersistEntity a)
+    :: (MonadIO m, PersistEntity a, SqlBackendCanWrite backend)
     => SqlQuery (SqlExpr (Insertion a))
-    -> SqlWriteT m Int64
+    -> R.ReaderT backend m Int64
 insertSelectCount a = rawEsqueleto INSERT_INTO a
 
 -- | Renders an expression into 'Text'. Only useful for creating a textual

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -2536,10 +2536,11 @@ rawSelectSource
     ( SqlSelect a r
     , MonadIO m1
     , MonadIO m2
+    , SqlBackendCanRead backend
     )
     => Mode
     -> SqlQuery a
-    -> SqlReadT m1 (Acquire (C.ConduitT () r m2 ()))
+    -> R.ReaderT backend m1 (Acquire (C.ConduitT () r m2 ()))
 rawSelectSource mode query = do
     conn <- projectBackend <$> R.ask
     let _ = conn :: SqlBackend
@@ -2622,9 +2623,10 @@ select
     ::
     ( SqlSelect a r
     , MonadIO m
+    , SqlBackendCanRead backend
     )
     => SqlQuery a
-    -> SqlReadT m [r]
+    -> R.ReaderT backend m [r]
 select query = do
     res <- rawSelectSource SELECT query
     conn <- R.ask
@@ -2656,7 +2658,7 @@ select query = do
 --      return person
 -- @
 
-selectOne :: (SqlSelect a r, MonadIO m) => SqlQuery a -> SqlReadT m (Maybe r)
+selectOne :: (SqlSelect a r, MonadIO m, SqlBackendCanRead backend) => SqlQuery a -> R.ReaderT backend m (Maybe r)
 selectOne query = fmap Maybe.listToMaybe $ select $ limit 1 >> query
 
 -- | (Internal) Run a 'C.Source' of rows.


### PR DESCRIPTION
This PR removes the `SqlReadT` and `SqlWriteT` uses that would trigger compilation errors for folks on GHC 9.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
