### PR TITLE
Skip Haddock for GHC 8.6.5

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -72,5 +72,6 @@ jobs:
             ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal v2-build --disable-optimization -j $CONFIG
       - run: cabal v2-test --disable-optimization -j $CONFIG --test-options "--fail-on-focus"
-      - run: cabal v2-haddock -j $CONFIG
+      - if: ${{ matrix.ghc != "8.6.5" }}
+        run: cabal v2-haddock -j $CONFIG
       - run: cabal v2-sdist

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -72,6 +72,6 @@ jobs:
             ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal v2-build --disable-optimization -j $CONFIG
       - run: cabal v2-test --disable-optimization -j $CONFIG --test-options "--fail-on-focus"
-      - if: ${{ matrix.ghc != "8.6.5" }}
+      - if: ${{ matrix.ghc != '8.6.5' }}
         run: cabal v2-haddock -j $CONFIG
       - run: cabal v2-sdist

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -4,8 +4,18 @@ packages:
   - '.'
   - 'examples'
 
+allow-newer: true
+
 extra-deps:
   - persistent-2.14.0.1
+  - persistent-postgresql-2.13.5.0
+  - persistent-mysql-2.13.0.0
+  - persistent-sqlite-2.13.0.0
+  - postgresql-simple-0.6.4
+  - postgresql-libpq-0.9.4.3
+  - time-compat-1.9.6.1
+  - base-orphans-0.8.6
+  - hashable-1.2.7.0
   - lift-type-0.1.0.1
   - th-lift-instances-0.1.19
   - th-lift-0.8.2

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -5,11 +5,7 @@ packages:
   - 'examples'
 
 extra-deps:
-  - git: https://github.com/yesodweb/persistent
-    commit: 0b8f9f3305c9b60c947565de882abfbfd8cb5702
-    subdirs:
-      - persistent
-      - persistent-template
-      - persistent-mysql
-      - persistent-postgresql
-      - persistent-sqlite
+  - persistent-2.14.0.1
+  - lift-type-0.1.0.1
+  - th-lift-instances-0.1.19
+  - th-lift-0.8.2


### PR DESCRIPTION
[GHC 8.6.5 is broken with module re-exports](https://github.com/haskell/haddock/issues/979#issuecomment-485341270). We can either re-export everything, or just skip building Haddock. I'd rather skip building Haddocks for an old GHC than make the code experience worse, or more fragile.

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
