### PR TITLE
Add `ToAlias`, `ToAliasReference` for <=16-tuples

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+3.5.7.0
+=======
+- @ivanbakel
+    - [#328](https://github.com/bitemyapp/esqueleto/pull/328)
+        - Add `ToAlias` instances for 9- to 16-tuples
+        - Add `ToAliasReference` instances for 9- to 16-tuples
+
 3.5.6.1
 =======
 - @9999years

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.6.1
+version:        3.5.7.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental/ToAlias.hs
+++ b/src/Database/Esqueleto/Experimental/ToAlias.hs
@@ -90,3 +90,127 @@ instance ( ToAlias a
          , ToAlias h
          ) => ToAlias (a,b,c,d,e,f,g,h) where
     toAlias x = to8 <$> (toAlias $ from8 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         ) => ToAlias (a,b,c,d,e,f,g,h,i) where
+    toAlias x = to9 <$> (toAlias $ from9 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         , ToAlias j
+         ) => ToAlias (a,b,c,d,e,f,g,h,i,j) where
+    toAlias x = to10 <$> (toAlias $ from10 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         , ToAlias j
+         , ToAlias k
+         ) => ToAlias (a,b,c,d,e,f,g,h,i,j,k) where
+    toAlias x = to11 <$> (toAlias $ from11 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         , ToAlias j
+         , ToAlias k
+         , ToAlias l
+         ) => ToAlias (a,b,c,d,e,f,g,h,i,j,k,l) where
+    toAlias x = to12 <$> (toAlias $ from12 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         , ToAlias j
+         , ToAlias k
+         , ToAlias l
+         , ToAlias m
+         ) => ToAlias (a,b,c,d,e,f,g,h,i,j,k,l,m) where
+    toAlias x = to13 <$> (toAlias $ from13 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         , ToAlias j
+         , ToAlias k
+         , ToAlias l
+         , ToAlias m
+         , ToAlias n
+         ) => ToAlias (a,b,c,d,e,f,g,h,i,j,k,l,m,n) where
+    toAlias x = to14 <$> (toAlias $ from14 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         , ToAlias j
+         , ToAlias k
+         , ToAlias l
+         , ToAlias m
+         , ToAlias n
+         , ToAlias o
+         ) => ToAlias (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) where
+    toAlias x = to15 <$> (toAlias $ from15 x)
+
+instance ( ToAlias a
+         , ToAlias b
+         , ToAlias c
+         , ToAlias d
+         , ToAlias e
+         , ToAlias f
+         , ToAlias g
+         , ToAlias h
+         , ToAlias i
+         , ToAlias j
+         , ToAlias k
+         , ToAlias l
+         , ToAlias m
+         , ToAlias n
+         , ToAlias o
+         , ToAlias p
+         ) => ToAlias (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) where
+    toAlias x = to16 <$> (toAlias $ from16 x)

--- a/src/Database/Esqueleto/Experimental/ToAliasReference.hs
+++ b/src/Database/Esqueleto/Experimental/ToAliasReference.hs
@@ -88,3 +88,126 @@ instance ( ToAliasReference a
          ) => ToAliasReference (a,b,c,d,e,f,g,h) where
     toAliasReference ident x = to8 <$> (toAliasReference ident $ from8 x)
 
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i) where
+    toAliasReference ident x = to9 <$> (toAliasReference ident $ from9 x)
+
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         , ToAliasReference j
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i,j) where
+    toAliasReference ident x = to10 <$> (toAliasReference ident $ from10 x)
+
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         , ToAliasReference j
+         , ToAliasReference k
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i,j,k) where
+    toAliasReference ident x = to11 <$> (toAliasReference ident $ from11 x)
+
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         , ToAliasReference j
+         , ToAliasReference k
+         , ToAliasReference l
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i,j,k,l) where
+    toAliasReference ident x = to12 <$> (toAliasReference ident $ from12 x)
+
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         , ToAliasReference j
+         , ToAliasReference k
+         , ToAliasReference l
+         , ToAliasReference m
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i,j,k,l,m) where
+    toAliasReference ident x = to13 <$> (toAliasReference ident $ from13 x)
+
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         , ToAliasReference j
+         , ToAliasReference k
+         , ToAliasReference l
+         , ToAliasReference m
+         , ToAliasReference n
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i,j,k,l,m,n) where
+    toAliasReference ident x = to14 <$> (toAliasReference ident $ from14 x)
+
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         , ToAliasReference j
+         , ToAliasReference k
+         , ToAliasReference l
+         , ToAliasReference m
+         , ToAliasReference n
+         , ToAliasReference o
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) where
+    toAliasReference ident x = to15 <$> (toAliasReference ident $ from15 x)
+
+instance ( ToAliasReference a
+         , ToAliasReference b
+         , ToAliasReference c
+         , ToAliasReference d
+         , ToAliasReference e
+         , ToAliasReference f
+         , ToAliasReference g
+         , ToAliasReference h
+         , ToAliasReference i
+         , ToAliasReference j
+         , ToAliasReference k
+         , ToAliasReference l
+         , ToAliasReference m
+         , ToAliasReference n
+         , ToAliasReference o
+         , ToAliasReference p
+         ) => ToAliasReference (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) where
+    toAliasReference ident x = to16 <$> (toAliasReference ident $ from16 x)

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -3497,6 +3497,9 @@ instance ( SqlSelect a ra
 from11P :: Proxy (a,b,c,d,e,f,g,h,i,j,k) -> Proxy ((a,b),(c,d),(e,f),(g,h),(i,j),k)
 from11P = const Proxy
 
+from11 :: (a,b,c,d,e,f,g,h,i,j,k) -> ((a,b),(c,d),(e,f),(g,h),(i,j),k)
+from11 (a,b,c,d,e,f,g,h,i,j,k) = ((a,b),(c,d),(e,f),(g,h),(i,j),k)
+
 to11 :: ((a,b),(c,d),(e,f),(g,h),(i,j),k) -> (a,b,c,d,e,f,g,h,i,j,k)
 to11 ((a,b),(c,d),(e,f),(g,h),(i,j),k) = (a,b,c,d,e,f,g,h,i,j,k)
 
@@ -3533,6 +3536,9 @@ instance ( SqlSelect a ra
 
 from12P :: Proxy (a,b,c,d,e,f,g,h,i,j,k,l) -> Proxy ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l))
 from12P = const Proxy
+
+from12 :: (a,b,c,d,e,f,g,h,i,j,k,l) -> ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l))
+from12 (a,b,c,d,e,f,g,h,i,j,k,l) = ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l))
 
 to12 :: ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l)) -> (a,b,c,d,e,f,g,h,i,j,k,l)
 to12 ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l)) = (a,b,c,d,e,f,g,h,i,j,k,l)
@@ -3572,6 +3578,9 @@ instance ( SqlSelect a ra
 
 from13P :: Proxy (a,b,c,d,e,f,g,h,i,j,k,l,m) -> Proxy ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),m)
 from13P = const Proxy
+
+from13 :: (a,b,c,d,e,f,g,h,i,j,k,l,m) -> ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),m)
+from13 (a,b,c,d,e,f,g,h,i,j,k,l,m) = ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),m)
 
 to13 :: ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),m) -> (a,b,c,d,e,f,g,h,i,j,k,l,m)
 to13 ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),m) = (a,b,c,d,e,f,g,h,i,j,k,l,m)
@@ -3613,6 +3622,9 @@ instance ( SqlSelect a ra
 
 from14P :: Proxy (a,b,c,d,e,f,g,h,i,j,k,l,m,n) -> Proxy ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n))
 from14P = const Proxy
+
+from14 :: (a,b,c,d,e,f,g,h,i,j,k,l,m,n) -> ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n))
+from14 (a,b,c,d,e,f,g,h,i,j,k,l,m,n) = ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n))
 
 to14 :: ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n)) -> (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
 to14 ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n)) = (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
@@ -3656,6 +3668,9 @@ instance ( SqlSelect a ra
 
 from15P :: Proxy (a,b,c,d,e,f,g,h,i,j,k,l,m,n, o) -> Proxy ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),o)
 from15P = const Proxy
+
+from15 :: (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) -> ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),o)
+from15 (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) = ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),o)
 
 to15 :: ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),o) -> (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
 to15 ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),o) = (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
@@ -3701,6 +3716,9 @@ instance ( SqlSelect a ra
 
 from16P :: Proxy (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) -> Proxy ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),(o,p))
 from16P = const Proxy
+
+from16 :: (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) -> ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),(o,p))
+from16 (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) = ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),(o,p))
 
 to16 :: ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),(o,p)) -> (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p)
 to16 ((a,b),(c,d),(e,f),(g,h),(i,j),(k,l),(m,n),(o,p)) = (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p)


### PR DESCRIPTION
This adds a `ToAlias` and `ToAliasReference` instance for every tuple size from 9 to 16. These tuple sizes are supported elsewhere, but those typeclasses only had instances for tuples up to size 8.

This also adds `from*` functions for tuples of size 9-16, which didn't exist before.

Do I need to add Haddocks and `@since` declarations for these functions, given that they're in the `Internal` module?

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
