### PR TITLE
Add `ToAlias`, `ToAliasReference` to `deriveEsqueletoRecord`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
-3.5.6.1
+3.5.7.0
+=======
+- @ivanbakel
+    - [#329](https://github.com/bitemyapp/esqueleto/pull/329)
+        - Add `ToAlias` and `ToAliasReference` instances to the type produced
+          by `deriveEsqueletoRecord`, allowing in-SQL records to be used in
+          CTEs
+
 =======
 - @9999years
     - [#324](https://github.com/bitemyapp/esqueleto/pull/324)

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.6.1
+version:        3.5.7.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/test/Common/Record.hs
+++ b/test/Common/Record.hs
@@ -144,3 +144,32 @@ testDeriveEsqueletoRecord = describe "deriveEsqueletoRecord" $ do
                                 }
                    } -> addr1 == addr2 -- The keys should match.
                  _ -> False)
+
+    itDb "can be used in a CTE" $ do
+        setup
+        records <- select $ do
+            recordCTE <- with myRecordQuery
+            record <- from recordCTE
+            pure record
+        let sortedRecords = sortOn (\MyRecord {myName} -> myName) records
+        liftIO $ sortedRecords !! 0
+          `shouldSatisfy`
+          (\case MyRecord { myName = "Rebecca"
+                          , myAge = Just 10
+                          , myUser = Entity _ User { userAddress  = Nothing
+                                                   , userName = "Rebecca"
+                                                   }
+                          , myAddress = Nothing
+                          } -> True
+                 _ -> False)
+        liftIO $ sortedRecords !! 1
+          `shouldSatisfy`
+          (\case MyRecord { myName = "Some Guy"
+                          , myAge = Just 10
+                          , myUser = Entity _ User { userAddress  = Just addr1
+                                                   , userName = "Some Guy"
+                                                   }
+                          , myAddress = Just (Entity addr2 Address {addressAddress = "30-50 Feral Hogs Rd"})
+                          } -> addr1 == addr2 -- The keys should match.
+                 _ -> False)
+


### PR DESCRIPTION
These instances are required for some Esqueleto functions, such as using records in Common Table Expressions with `with`.

They are simply defined by lifting the record SQL constructor over the appropriate monad.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
