### PR TITLE
Add customisation of auto-gen'ed SQL record names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,16 @@
+3.5.8.0
+=======
+- @ivanbakel
+    - [#331](https://github.com/bitemyapp/esqueleto/pull/331)
+        - Add `deriveEsqueletoRecordWith` to derive Esqueleto instances for
+          records using custom deriving settings.
+        - Add `DeriveEsqueletoRecordSettings` to control how Esqueleto record
+          instances are derived.
+        - Add `sqlNameModifier` to control how Esqueleto record instance
+          deriving generates the SQL record type name.
+        - Add `sqlFieldModifier` to control how Esqueleto record instance
+          deriving generates the SQL record fields.
+
 3.5.7.1
 =======
 - @belevy

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.7.1
+version:        3.5.8.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Record.hs
+++ b/src/Database/Esqueleto/Record.hs
@@ -122,13 +122,19 @@ deriveEsqueletoRecord :: Name -> Q [Dec]
 deriveEsqueletoRecord = deriveEsqueletoRecordWith defaultDeriveEsqueletoRecordSettings
 
 -- | Codegen settings for 'deriveEsqueletoRecordWith'.
+--
+-- @since 3.5.8.0
 data DeriveEsqueletoRecordSettings = DeriveEsqueletoRecordSettings
   { sqlNameModifier :: String -> String
     -- ^ Function applied to the Haskell record's type name and constructor
     -- name to produce the SQL record's type name and constructor name.
+    --
+    -- @since 3.5.8.0
   , sqlFieldModifier :: String -> String
     -- ^ Function applied to the Haskell record's field names to produce the
     -- SQL record's field names.
+    --
+    -- @since 3.5.8.0
   }
 
 -- | The default codegen settings for 'deriveEsqueletoRecord'.
@@ -137,6 +143,8 @@ data DeriveEsqueletoRecordSettings = DeriveEsqueletoRecordSettings
 -- in certain cases (see 'deriveEsqueletoRecord'.) If you don't want to do this,
 -- change the value of 'sqlFieldModifier' so the field names of the generated SQL
 -- record different from those of the Haskell record.
+--
+-- @since 3.5.8.0
 defaultDeriveEsqueletoRecordSettings :: DeriveEsqueletoRecordSettings
 defaultDeriveEsqueletoRecordSettings = DeriveEsqueletoRecordSettings
   { sqlNameModifier = ("Sql" ++)
@@ -151,6 +159,8 @@ defaultDeriveEsqueletoRecordSettings = DeriveEsqueletoRecordSettings
 -- This is a variant of 'deriveEsqueletoRecord' which allows you to avoid the
 -- use of @{-# LANGUAGE DuplicateRecordFields #-}@, by configuring the
 -- 'DeriveEsqueletoRecordSettings' used to generate the SQL record.
+--
+-- @since 3.5.8.0
 deriveEsqueletoRecordWith :: DeriveEsqueletoRecordSettings -> Name -> Q [Dec]
 deriveEsqueletoRecordWith settings originalName = do
   info <- getRecordInfo settings originalName


### PR DESCRIPTION
This adds an Aeson-inspired ability to configure how `deriveEsqueletoRecord` generates the SQL record type, in particular which names it generates for the record type itself and its fields.

This is because `DuplicateRecordFields` is a painful extension to use, and avoiding it through module structuring is also painful. A nicer solution for avoiding duplicate record fields is to simply not generate them, and allow the user to specify how record fields should be generated so they don't overlap.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
