### PR TITLE
ggJoseph/support for update of skip locked

### DIFF
--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -1,8 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto
-
-version:        3.5.5.0
+version:        3.6.0.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -83,6 +83,7 @@ module Database.Esqueleto {-# WARNING "This module will switch over to the Exper
   , OrderBy
   , DistinctOn
   , LockingKind(..)
+  , LockableEntity(..)
   , SqlString
     -- ** Joins
   , InnerJoin(..)

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -174,6 +174,7 @@ module Database.Esqueleto.Experimental
     , OrderBy
     , DistinctOn
     , LockingKind(..)
+    , LockableEntity(..)
     , SqlString
 
       -- ** Joins

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1426,7 +1426,7 @@ data LockingKind where
       -- ^ @LOCK IN SHARE MODE@ syntax.  Supported by MySQL.
       --
       -- @since 2.2.7
-    ForUpdateOfSkipLocked :: PersistEntity val => (SqlExpr (Entity val)) -> LockingKind
+    ForUpdateOfSkipLocked :: PersistEntity val => [(SqlExpr (Entity val))] -> LockingKind
       -- ^ @FOR UPDATE OF tablename SKIP LOCKED@ syntax. Supported by MySQL, and PostgreSQL
       --
       -- @since 3.5.4.2
@@ -3049,8 +3049,9 @@ makeLocking info lockingClause =
     Just ForUpdateSkipLocked -> ("\nFOR UPDATE SKIP LOCKED", [])
     Just ForShare            -> ("\nFOR SHARE", [])
     Just LockInShareMode     -> ("\nLOCK IN SHARE MODE", [])
-    Just (ForUpdateOfSkipLocked (ERaw _ f)) ->
-      first (\name -> "\nFOR UPDATE OF " <> name <> " SKIP LOCKED") (f Never info)
+    Just (ForUpdateOfSkipLocked rawNames) ->
+      let names = uncommas' $ (\(ERaw _ f) -> (f Never info)) <$> rawNames in
+      first (\n -> "\nFOR UPDATE OF " <> n <> " SKIP LOCKED") names
     Nothing -> mempty
 
 parens :: TLB.Builder -> TLB.Builder

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1429,18 +1429,24 @@ data LockingKind where
     ForUpdateOfSkipLocked :: [LockableEntity] -> LockingKind
       -- ^ @FOR UPDATE OF tablename SKIP LOCKED@ syntax. Supported by MySQL, and PostgreSQL
       --
-      -- @since 3.5.4.2
+      -- @since 3.5.5.0
 
--- | Wraps table type entities for usage in LockingKind. Usage:
--- Example of usage:
+-- | Wraps table type entities for use with LockingKind. 
+--
+-- Example use:
 --
 -- @
 -- select $ do
---   from $ \(p `InnerJoin` b) -> do
---     on (p ^. PersonId ==. b ^. BlogPostAuthorId)
---   locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
---   return p
+--     (p :& bp) <- from $ 
+--         table @Person
+--         `innerJoin` table @BlogPost
+--             `on` do
+--                 \(p :& bp) -> p ^. PersonId ==. b ^. BlogPostAuthorId
+--     locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
+--     return p
 -- @
+--
+-- @since 3.5.5.0
 data LockableEntity where
   LockableEntity :: PersistEntity val => (SqlExpr (Entity val)) -> LockableEntity
 

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1431,7 +1431,16 @@ data LockingKind where
       --
       -- @since 3.5.4.2
 
--- | Existential type to wrap table type entities for LockingKind
+-- | Wraps table type entities for usage in LockingKind. Usage:
+-- Example of usage:
+--
+-- @
+-- select $ do
+--   from $ \(p `InnerJoin` b) -> do
+--     on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+--   locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
+--   return p
+-- @
 data LockableEntity where
   LockableEntity :: PersistEntity val => (SqlExpr (Entity val)) -> LockableEntity
 

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1,18 +1,19 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeApplications #-}
-{-# language DerivingStrategies, GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,8 +27,6 @@
 -- tracker so we can safely support it.
 module Database.Esqueleto.Internal.Internal where
 
-import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NEL
 import Control.Applicative ((<|>))
 import Control.Arrow (first, (***))
 import Control.Exception (Exception, throw, throwIO)
@@ -38,6 +37,8 @@ import Control.Monad.Trans.Resource (MonadResource, release)
 import Data.Acquire (Acquire, allocateAcquire, with)
 import Data.Int (Int64)
 import Data.List (intersperse)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Maybe as Maybe
 #if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
@@ -46,9 +47,11 @@ import qualified Control.Monad.Trans.Reader as R
 import qualified Control.Monad.Trans.State as S
 import qualified Control.Monad.Trans.Writer as W
 import qualified Data.ByteString as B
+import Data.Coerce (coerce)
 import qualified Data.Conduit as C
 import qualified Data.Conduit.List as CL
 import qualified Data.HashSet as HS
+import Data.Kind (Type)
 import qualified Data.Map.Strict as Map
 import qualified Data.Monoid as Monoid
 import Data.Proxy (Proxy(..))
@@ -60,19 +63,17 @@ import qualified Data.Text.Lazy.Builder as TLB
 import Data.Typeable (Typeable)
 import Database.Esqueleto.Internal.ExprParser (TableAccess(..), parseOnExpr)
 import Database.Esqueleto.Internal.PersistentImport
-import Database.Persist.SqlBackend
+import Database.Persist (EntityNameDB(..), FieldNameDB(..), SymbolToField(..))
 import qualified Database.Persist
-import Database.Persist (FieldNameDB(..), EntityNameDB(..), SymbolToField(..))
 import Database.Persist.Sql.Util
        ( entityColumnCount
-       , keyAndEntityColumnNames
        , isIdField
+       , keyAndEntityColumnNames
        , parseEntityValues
        )
-import Text.Blaze.Html (Html)
-import Data.Coerce (coerce)
-import Data.Kind (Type)
+import Database.Persist.SqlBackend
 import GHC.Records
+import Text.Blaze.Html (Html)
 
 -- | (Internal) Start a 'from' query with an entity. 'from'
 -- does two kinds of magic using 'fromStart', 'fromJoin' and
@@ -3042,13 +3043,13 @@ makeLimit (conn, _) (Limit ml mo) =
     in (TLB.fromText limitRaw, mempty)
 
 makeLocking :: IdentInfo -> LockingClause -> (TLB.Builder, [PersistValue])
-makeLocking info lockingClause = 
+makeLocking info lockingClause =
   case Monoid.getLast lockingClause of
     Just ForUpdate           -> ("\nFOR UPDATE", [])
     Just ForUpdateSkipLocked -> ("\nFOR UPDATE SKIP LOCKED", [])
     Just ForShare            -> ("\nFOR SHARE", [])
     Just LockInShareMode     -> ("\nLOCK IN SHARE MODE", [])
-    Just (ForUpdateOfSkipLocked (ERaw _ f)) -> 
+    Just (ForUpdateOfSkipLocked (ERaw _ f)) ->
       first (\name -> "\nFOR UPDATE OF " <> name <> " SKIP LOCKED") (f Never info)
     Nothing -> mempty
 

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1429,7 +1429,7 @@ data LockingKind where
     ForUpdateOfSkipLocked :: [LockableEntity] -> LockingKind
       -- ^ @FOR UPDATE OF tablename SKIP LOCKED@ syntax. Supported by MySQL, and PostgreSQL
       --
-      -- @since 3.5.5.0
+      -- @since 3.6.0.0
 
 -- | Wraps table type entities for use with LockingKind. 
 --
@@ -1446,7 +1446,7 @@ data LockingKind where
 --     return p
 -- @
 --
--- @since 3.5.5.0
+-- @since 3.6.0.0
 data LockableEntity where
   LockableEntity :: PersistEntity val => (SqlExpr (Entity val)) -> LockableEntity
 

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1429,7 +1429,7 @@ data LockingKind where
     ForUpdateOfSkipLocked :: PersistEntity val => (SqlExpr (Entity val)) -> LockingKind
       -- ^ @FOR UPDATE OF tablename SKIP LOCKED@ syntax. Supported by MySQL, and PostgreSQL
       --
-      -- @since 3.5.4.0
+      -- @since 3.5.4.2
 
 -- | Phantom class of data types that are treated as strings by the
 -- RDBMS.  It has no methods because it's only used to avoid type

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1442,7 +1442,7 @@ data LockingKind where
 --         `innerJoin` table @BlogPost
 --             `on` do
 --                 \(p :& bp) -> p ^. PersonId ==. b ^. BlogPostAuthorId
---     locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
+--     forUpdateOfSkipLocked [LockableEntity p,LockableEntity b]
 --     return p
 -- @
 --

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -3042,14 +3042,15 @@ makeLimit (conn, _) (Limit ml mo) =
     in (TLB.fromText limitRaw, mempty)
 
 makeLocking :: IdentInfo -> LockingClause -> (TLB.Builder, [PersistValue])
-makeLocking info = flip (,) [] . maybe mempty toTLB . Monoid.getLast
-  where
-    toTLB ForUpdate           = "\nFOR UPDATE"
-    toTLB ForUpdateSkipLocked = "\nFOR UPDATE SKIP LOCKED"
-    toTLB ForShare            = "\nFOR SHARE"
-    toTLB LockInShareMode     = "\nLOCK IN SHARE MODE"
-    toTLB (ForUpdateOfSkipLocked (ERaw _ f))=
-      "\nFOR UPDATE OF " <> fst (f Never info) <> " SKIP LOCKED"
+makeLocking info lockingClause = 
+  case Monoid.getLast lockingClause of
+    Just ForUpdate           -> ("\nFOR UPDATE", [])
+    Just ForUpdateSkipLocked -> ("\nFOR UPDATE SKIP LOCKED", [])
+    Just ForShare            -> ("\nFOR SHARE", [])
+    Just LockInShareMode     -> ("\nLOCK IN SHARE MODE", [])
+    Just (ForUpdateOfSkipLocked (ERaw _ f)) -> 
+      first (\name -> "\nFOR UPDATE OF " <> name <> " SKIP LOCKED") (f Never info)
+    Nothing -> mempty
 
 parens :: TLB.Builder -> TLB.Builder
 parens b = "(" <> (b <> ")")

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1426,10 +1426,14 @@ data LockingKind where
       -- ^ @LOCK IN SHARE MODE@ syntax.  Supported by MySQL.
       --
       -- @since 2.2.7
-    ForUpdateOfSkipLocked :: PersistEntity val => [(SqlExpr (Entity val))] -> LockingKind
+    ForUpdateOfSkipLocked :: [LockableEntity] -> LockingKind
       -- ^ @FOR UPDATE OF tablename SKIP LOCKED@ syntax. Supported by MySQL, and PostgreSQL
       --
       -- @since 3.5.4.2
+
+-- | Existential type to wrap table type entities for LockingKind
+data LockableEntity where
+  LockableEntity :: PersistEntity val => (SqlExpr (Entity val)) -> LockableEntity
 
 -- | Phantom class of data types that are treated as strings by the
 -- RDBMS.  It has no methods because it's only used to avoid type
@@ -3050,7 +3054,7 @@ makeLocking info lockingClause =
     Just ForShare            -> ("\nFOR SHARE", [])
     Just LockInShareMode     -> ("\nLOCK IN SHARE MODE", [])
     Just (ForUpdateOfSkipLocked rawNames) ->
-      let names = uncommas' $ (\(ERaw _ f) -> (f Never info)) <$> rawNames in
+      let names = uncommas' $ (\(LockableEntity (ERaw _ f)) -> (f Never info)) <$> rawNames in
       first (\n -> "\nFOR UPDATE OF " <> n <> " SKIP LOCKED") names
     Nothing -> mempty
 

--- a/src/Database/Esqueleto/Legacy.hs
+++ b/src/Database/Esqueleto/Legacy.hs
@@ -84,6 +84,7 @@ module Database.Esqueleto.Legacy
   , OrderBy
   , DistinctOn
   , LockingKind(..)
+  , LockableEntity(..)
   , SqlString
     -- ** Joins
   , InnerJoin(..)

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -27,6 +27,7 @@ module Database.Esqueleto.PostgreSQL
     , upsertBy
     , insertSelectWithConflict
     , insertSelectWithConflictCount
+    , forUpdateOfSkipLocked
     , filterWhere
     , values
     -- * Internal
@@ -52,8 +53,8 @@ import qualified Database.Esqueleto.Experimental as Ex
 import qualified Database.Esqueleto.Experimental.From as Ex
 import Database.Esqueleto.Internal.Internal hiding (random_)
 import Database.Esqueleto.Internal.PersistentImport hiding (upsert, upsertBy)
-import Database.Persist.Class (OnlyOneUniqueKey)
 import Database.Persist (ConstraintNameDB(..), EntityNameDB(..))
+import Database.Persist.Class (OnlyOneUniqueKey)
 import Database.Persist.SqlBackend
 
 -- | (@random()@) Split out into database specific modules
@@ -437,3 +438,6 @@ values exprs = Ex.From $ do
             <> "(" <> TLB.fromLazyText colsAliases <> ")"
             , params
             )
+
+forUpdateOfSkipLocked :: [LockableEntity] -> SqlQuery ()
+forUpdateOfSkipLocked = locking . ForUpdateOfSkipLocked

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1268,14 +1268,14 @@ testPostgresqlLocking =
                       select $ do
                         from $ \(p `LeftOuterJoin` b) -> do
                           on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                          locking (ForUpdateOfSkipLocked [LockableEntity p])
+                          EP.forUpdateOfSkipLocked [LockableEntity p]
                           return p
 
                     nonLockedRowsSpecifyAllTables <-
                       select $ do
                         from $ \(p `InnerJoin` b) -> do
                           on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                          locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
+                          EP.forUpdateOfSkipLocked [LockableEntity p,LockableEntity b]
                           return p
 
                     pure $ do
@@ -1295,7 +1295,7 @@ testPostgresqlLocking =
                 nonLockedRowsAfterUpdate <- select $ do
                                       from $ \(p `LeftOuterJoin` b) -> do
                                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                        locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                        EP.forUpdateOfSkipLocked [LockableEntity p]
                                         return p
 
                 asserting $ sideThreadAsserts
@@ -1314,7 +1314,7 @@ testPostgresqlLocking =
                           select $ do
                              from $ \(p `LeftOuterJoin` b) -> do
                                on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                               locking (ForUpdateOfSkipLocked [LockableEntity p])
+                               EP.forUpdateOfSkipLocked [LockableEntity p]
                                return p
 
                         pure $ length nonLockedRowsSpecifiedTable `shouldBe` 2
@@ -1335,7 +1335,7 @@ testPostgresqlLocking =
                 nonLockedRowsAfterUpdate <- select $ do
                                       from $ \(p `LeftOuterJoin` b) -> do
                                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                        locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                        EP.forUpdateOfSkipLocked [LockableEntity p]
                                         return p
 
                 asserting sideThreadAsserts
@@ -1354,14 +1354,14 @@ testPostgresqlLocking =
                               from $ \(p `LeftOuterJoin` b) -> do
                                 on (p ^. PersonId ==. b ^. BlogPostAuthorId)
                                 where_ (b ^. BlogPostTitle ==. val "A")
-                                locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                EP.forUpdateOfSkipLocked [LockableEntity p]
                                 return p
 
                           nonLockedRows <-
                             select $ do
                               from $ \(p `LeftOuterJoin` b) -> do
                                 on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                EP.forUpdateOfSkipLocked [LockableEntity p]
                                 return p
 
                           pure $ do
@@ -1388,7 +1388,7 @@ testPostgresqlLocking =
                 nonLockedRowsAfterUpdate <- select $ do
                                       from $ \(p `LeftOuterJoin` b) -> do
                                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                        locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                        EP.forUpdateOfSkipLocked [LockableEntity p]
                                         return p
 
                 asserting sideThreadAsserts

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1234,182 +1234,165 @@ testCommonTableExpressions = do
 testPostgresqlLocking :: SpecDb
 testPostgresqlLocking =
     describe "For update skip locked locking" $ sequential $ do
+        let mkInitialStateForLockingTest connection =
+              flip runSqlPool connection $ do
+                  p1k <- insert p1
+                  p2k <- insert p2
+                  p3k <- insert p3
+                  blogPosts <- mapM insert'
+                    [ BlogPost "A" p1k
+                    , BlogPost "B" p2k
+                    , BlogPost "C" p3k ]
+                  pure ([p1k, p2k, p3k], entityKey <$> blogPosts)
+            cleanupLockingTest connection (personKeys, blogPostKeys) =
+              flip runSqlPool connection $ do
+                void $ forM_ blogPostKeys P.delete
+                void $ forM_ personKeys P.delete
+
         it "skips locked rows for a locking select" $ \connection -> do
+          bracket (mkInitialStateForLockingTest connection) (cleanupLockingTest connection) $ \(personKeys, blogPostKeys) -> do
+            waitMainThread <- newEmptyMVar
 
-          (personKeys, blogPostKeys) <- flip runSqlPool connection $ do
-              p1k <- insert p1
-              p2k <- insert p2
-              p3k <- insert p3
-              blogPosts <- mapM insert'
-                [ BlogPost "A" p1k
-                , BlogPost "B" p2k
-                , BlogPost "C" p3k ]
-              pure ([p1k, p2k, p3k], entityKey <$> blogPosts)
+            let sideThread :: IO Expectation
+                sideThread = do
+                  flip runSqlPool connection $ do
 
-          let sideThread :: IO Expectation
-              sideThread = do
-                flip runSqlPool connection $ do
+                    _ <- takeMVar waitMainThread
+                    nonLockedRowsNonSpecified <-
+                      select $ do
+                          p <- Experimental.from $ table @Person
+                          locking (ForUpdateSkipLocked)
+                          return p
 
-                  nonLockedRowsNonSpecified <-
-                    select $ do
-                        p <- Experimental.from $ table @Person
-                        locking (ForUpdateSkipLocked)
-                        return p
+                    nonLockedRowsSpecifiedTable <-
+                      select $ do
+                        from $ \(p `LeftOuterJoin` b) -> do
+                          on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                          locking (ForUpdateOfSkipLocked [LockableEntity p])
+                          return p
 
-                  nonLockedRowsSpecifiedTable <-
-                    select $ do
-                      from $ \(p `LeftOuterJoin` b) -> do
-                        on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                        locking (ForUpdateOfSkipLocked [LockableEntity p])
-                        return p
+                    nonLockedRowsSpecifyAllTables <-
+                      select $ do
+                        from $ \(p `InnerJoin` b) -> do
+                          on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                          locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
+                          return p
 
-                  nonLockedRowsSpecifyAllTables <-
-                    select $ do
-                      from $ \(p `InnerJoin` b) -> do
-                        on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                        locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
-                        return p
+                    pure $ do
+                          nonLockedRowsNonSpecified `shouldBe` []
+                          nonLockedRowsSpecifiedTable `shouldBe` []
+                          nonLockedRowsSpecifyAllTables `shouldBe` []
 
-                  pure $ do
-                        nonLockedRowsNonSpecified `shouldBe` []
-                        nonLockedRowsSpecifiedTable `shouldBe` []
-                        nonLockedRowsSpecifyAllTables `shouldBe` []
+            withAsync sideThread $ \sideThreadAsync -> do
+              void $ flip runSqlPool connection $ do
+                void $ select $ do
+                      person <- Experimental.from $ table @Person
+                      locking (ForUpdate)
+                      pure $ person ^. PersonId
 
-          withAsync sideThread $ \sideThreadAsync -> do
-            void $ flip runSqlPool connection $ do
-              void $ select $ do
-                    person <- Experimental.from $ table @Person
-                    locking (ForUpdate)
-                    pure $ person ^. PersonId
+                _ <- putMVar waitMainThread ()
+                sideThreadAsserts <- wait sideThreadAsync
+                nonLockedRowsAfterUpdate <- select $ do
+                                      from $ \(p `LeftOuterJoin` b) -> do
+                                        on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                        locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                        return p
 
-              sideThreadAsserts <- wait sideThreadAsync
-              nonLockedRowsAfterUpdate <- select $ do
-                                    from $ \(p `LeftOuterJoin` b) -> do
-                                      on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                      locking (ForUpdateOfSkipLocked [LockableEntity p])
-                                      return p
-
-              asserting $ sideThreadAsserts
-              asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
-
-          flip runSqlPool connection $ do
-            void $ forM_ blogPostKeys P.delete
-            void $ forM_ personKeys P.delete
+                asserting $ sideThreadAsserts
+                asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
 
         it "skips locked rows for a subselect update" $ \connection -> do
+          bracket (mkInitialStateForLockingTest connection) (cleanupLockingTest connection) $ \(personKeys, blogPostKeys) -> do
+            waitMainThread <- newEmptyMVar
 
-          (personKeys, blogPostKeys) <- flip runSqlPool connection $ do
-              p1k <- insert p1
-              p2k <- insert p2
-              p3k <- insert p3
-              blogPosts <- mapM insert'
-                [ BlogPost "A" p1k
-                , BlogPost "B" p2k
-                , BlogPost "C" p3k ]
-              pure ([p1k, p2k, p3k], entityKey <$> blogPosts)
+            let sideThread :: IO Expectation
+                sideThread =
+                      flip runSqlPool connection $ do
+                        liftIO $ takeMVar waitMainThread
 
-          let sideThread :: IO Expectation
-              sideThread =
-                     flip runSqlPool connection $ do
+                        nonLockedRowsSpecifiedTable <-
+                          select $ do
+                             from $ \(p `LeftOuterJoin` b) -> do
+                               on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                               locking (ForUpdateOfSkipLocked [LockableEntity p])
+                               return p
 
-                      nonLockedRowsSpecifiedTable <-
-                         select $ do
-                           from $ \(p `LeftOuterJoin` b) -> do
-                             on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                             locking (ForUpdateOfSkipLocked [LockableEntity p])
-                             return p
+                        pure $ length nonLockedRowsSpecifiedTable `shouldBe` 2
 
-                      pure $
-                            length nonLockedRowsSpecifiedTable `shouldBe` 2
+            withAsync sideThread $ \sideThreadAsync -> do
+              void $ flip runSqlPool connection $ do
+                update $ \p -> do
+                      set p [ PersonName =. val "ChangedName" ]
+                      where_ $ p ^. PersonId
+                        `in_` (subList_select $ do
+                                  person <- Experimental.from $ table @Person
+                                  limit 1
+                                  locking (ForUpdate)
+                                  pure $ person ^. PersonId)
 
-          withAsync sideThread $ \sideThreadAsync -> do
-            void $ flip runSqlPool connection $ do
-              update $ \p -> do
-                    set p [ PersonName =. val "ChangedName" ]
-                    where_ $ p ^. PersonId
-                      `in_` (subList_select $ do
-                                person <- Experimental.from $ table @Person
-                                limit 1
-                                locking (ForUpdate)
-                                pure $ person ^. PersonId)
+                liftIO $ putMVar waitMainThread ()
+                sideThreadAsserts <- wait sideThreadAsync
+                nonLockedRowsAfterUpdate <- select $ do
+                                      from $ \(p `LeftOuterJoin` b) -> do
+                                        on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                        locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                        return p
 
-              sideThreadAsserts <- wait sideThreadAsync
-              nonLockedRowsAfterUpdate <- select $ do
-                                    from $ \(p `LeftOuterJoin` b) -> do
-                                      on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                      locking (ForUpdateOfSkipLocked [LockableEntity p])
-                                      return p
-
-              asserting sideThreadAsserts
-              asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
-
-          flip runSqlPool connection $ do
-            void $ forM_ blogPostKeys P.delete
-            void $ forM_ personKeys P.delete
+                asserting sideThreadAsserts
+                asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
 
         it "skips locked rows for a subselect join update" $ \connection -> do
+          bracket (mkInitialStateForLockingTest connection) (cleanupLockingTest connection) $ \(personKeys, blogPostKeys) -> do
+            waitMainThread <- newEmptyMVar
 
-          (personKeys, blogPostKeys) <- flip runSqlPool connection $ do
-              p1k <- insert p1
-              p2k <- insert p2
-              p3k <- insert p3
-              blogPosts <- mapM insert'
-                [ BlogPost "A" p1k
-                , BlogPost "B" p2k
-                , BlogPost "C" p3k ]
-              pure ([p1k, p2k, p3k], entityKey <$> blogPosts)
+            let sideThread :: IO Expectation
+                sideThread =
+                      flip runSqlPool connection $ do
+                          liftIO $ takeMVar waitMainThread
+                          lockedRows <-
+                            select $ do
+                              from $ \(p `LeftOuterJoin` b) -> do
+                                on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                where_ (b ^. BlogPostTitle ==. val "A")
+                                locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                return p
 
-          let sideThread :: IO Expectation
-              sideThread =
-                    flip runSqlPool connection $ do
+                          nonLockedRows <-
+                            select $ do
+                              from $ \(p `LeftOuterJoin` b) -> do
+                                on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                return p
 
-                        lockedRows <-
-                          select $ do
-                            from $ \(p `LeftOuterJoin` b) -> do
-                              on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                              where_ (b ^. BlogPostTitle ==. val "A")
-                              locking (ForUpdateOfSkipLocked [LockableEntity p])
-                              return p
+                          pure $ do
+                              lockedRows `shouldBe` []
+                              length nonLockedRows `shouldBe` 2
 
-                        nonLockedRows <-
-                          select $ do
-                            from $ \(p `LeftOuterJoin` b) -> do
-                              on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                              locking (ForUpdateOfSkipLocked [LockableEntity p])
-                              return p
+            withAsync sideThread $ \sideThreadAsync -> do
+              void $ flip runSqlPool connection $ do
+                update $ \p -> do
+                      set p [ PersonName =. val "ChangedName" ]
+                      where_ $ p ^. PersonId
+                        `in_` (subList_select $ do
+                                (people :& blogPosts) <-
+                                    Experimental.from $ table @Person
+                                    `Experimental.leftJoin` table @BlogPost
+                                    `Experimental.on` (\(people :& blogPosts) ->
+                                            just (people ^. PersonId) ==. blogPosts ?. BlogPostAuthorId)
+                                where_ (blogPosts ?. BlogPostTitle ==. just (val "A"))
+                                pure $ people ^. PersonId
+                              )
 
-                        pure $ do
-                            lockedRows `shouldBe` []
-                            length nonLockedRows `shouldBe` 2
+                liftIO $ putMVar waitMainThread ()
+                sideThreadAsserts <- wait sideThreadAsync
+                nonLockedRowsAfterUpdate <- select $ do
+                                      from $ \(p `LeftOuterJoin` b) -> do
+                                        on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                        locking (ForUpdateOfSkipLocked [LockableEntity p])
+                                        return p
 
-          withAsync sideThread $ \sideThreadAsync -> do
-            void $ flip runSqlPool connection $ do
-              update $ \p -> do
-                    set p [ PersonName =. val "ChangedName" ]
-                    where_ $ p ^. PersonId
-                      `in_` (subList_select $ do
-                              (people :& blogPosts) <-
-                                  Experimental.from $ table @Person
-                                  `Experimental.leftJoin` table @BlogPost
-                                  `Experimental.on` (\(people :& blogPosts) ->
-                                          just (people ^. PersonId) ==. blogPosts ?. BlogPostAuthorId)
-                              where_ (blogPosts ?. BlogPostTitle ==. just (val "A"))
-                              pure $ people ^. PersonId
-                            )
-
-              sideThreadAsserts <- wait sideThreadAsync
-              nonLockedRowsAfterUpdate <- select $ do
-                                    from $ \(p `LeftOuterJoin` b) -> do
-                                      on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                      locking (ForUpdateOfSkipLocked [LockableEntity p])
-                                      return p
-
-              asserting sideThreadAsserts
-              asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
-
-          flip runSqlPool connection $ do
-            void $ forM_ blogPostKeys P.delete
-            void $ forM_ personKeys P.delete
+                asserting sideThreadAsserts
+                asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
 
 -- Since lateral queries arent supported in Sqlite or older versions of mysql
 -- the test is in the Postgres module

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1265,14 +1265,14 @@ testPostgresqlLocking =
                     select $ do
                       from $ \(p `LeftOuterJoin` b) -> do
                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                        locking (ForUpdateOfSkipLocked [p])
+                        locking (ForUpdateOfSkipLocked [LockableEntity p])
                         return p
                   
                   nonLockedRowsSpecifyAllTables <-
                     select $ do
-                      from $ \(p `innerJoin` b) -> do
+                      from $ \(p `InnerJoin` b) -> do
                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                        locking (ForUpdateOfSkipLocked [p,b])
+                        locking (ForUpdateOfSkipLocked [LockableEntity p,LockableEntity b])
                         return p
 
                   liftIO $ putMVar assertions $
@@ -1292,7 +1292,7 @@ testPostgresqlLocking =
             nonLockedRowsAfterUpdate <- select $ do
                                   from $ \(p `LeftOuterJoin` b) -> do
                                     on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                    locking (ForUpdateOfSkipLocked [p])
+                                    locking (ForUpdateOfSkipLocked [LockableEntity p])
                                     return p
 
             asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
@@ -1325,7 +1325,7 @@ testPostgresqlLocking =
                     select $ do
                       from $ \(p `LeftOuterJoin` b) -> do
                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                        locking (ForUpdateOfSkipLocked [p])
+                        locking (ForUpdateOfSkipLocked [LockableEntity p])
                         return p
 
                   liftIO $ putMVar assertions $
@@ -1347,7 +1347,7 @@ testPostgresqlLocking =
             nonLockedRowsAfterUpdate <- select $ do
                                   from $ \(p `LeftOuterJoin` b) -> do
                                     on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                    locking (ForUpdateOfSkipLocked [p])
+                                    locking (ForUpdateOfSkipLocked [LockableEntity p])
                                     return p
 
             asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
@@ -1381,14 +1381,14 @@ testPostgresqlLocking =
                       from $ \(p `LeftOuterJoin` b) -> do
                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
                         where_ (b ^. BlogPostTitle ==. val "A")
-                        locking (ForUpdateOfSkipLocked [p])
+                        locking (ForUpdateOfSkipLocked [LockableEntity p])
                         return p
 
                   nonLockedRows <-
                     select $ do
                       from $ \(p `LeftOuterJoin` b) -> do
                         on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                        locking (ForUpdateOfSkipLocked [p])
+                        locking (ForUpdateOfSkipLocked [LockableEntity p])
                         return p
 
                   liftIO $ putMVar assertions $
@@ -1415,7 +1415,7 @@ testPostgresqlLocking =
             nonLockedRowsAfterUpdate <- select $ do
                                   from $ \(p `LeftOuterJoin` b) -> do
                                     on (p ^. PersonId ==. b ^. BlogPostAuthorId)
-                                    locking (ForUpdateOfSkipLocked [p])
+                                    locking (ForUpdateOfSkipLocked [LockableEntity p])
                                     return p
 
             asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3


### PR DESCRIPTION
**Context:**
Support `FOR UPDATE Of tablename SKIP LOCKED` syntax:

Going to look at adding FOR x OF [tables] syntax to the rest of the locking kinds hence making this a draft (Plus updating to use the (_ &: _) esqueleto style instead of an existential type

This allows a the `FOR UPDATE SKIP LOCKED`  behaviour when you have a `LEFT OUTER JOIN` with a nullable side.  Currently you will get the error:
```
FOR UPDATE cannot be applied to the nullable side of an outer join
```
The workaround currently using esqueleto is to do seperate queries and then join them manually if you want to select rows for an update while skipping locked rows (or to just do a raw query). I ran into this situation at work.

See: https://www.postgresql.org/docs/current/sql-select.html
namely:
```
FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE } [ OF table_name [, ...] ] [ NOWAIT | SKIP LOCKED ] [...] ]
```
also documented in MySQL: 
https://dev.mysql.com/doc/refman/8.0/en/select.html

```
    [FOR {UPDATE | SHARE}
        [OF tbl_name [, tbl_name] ...]
        [NOWAIT | SKIP LOCKED]
      | LOCK IN SHARE MODE]
    [into_option]
```
Usage example would be
```
select $ do
    (p :& bp) <- from $ 
        table @Person
        `innerJoin` table @BlogPost
            `on` do
                \(p :& bp) -> p ^. PersonId ==. b ^. BlogPostAuthorId
    forUpdateOfSkipLocked [LockableEntity p,LockableEntity b]
    return p

```

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
