### PR TITLE
Support more locking kind

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-3.5.9.0
+3.5.9.2
 =======
 - @josephsumabat
     - [#339](https://github.com/bitemyapp/esqueleto/pull/333)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 3.5.9.0
 =======
 - @josephsumabat
-    - [#333](https://github.com/bitemyapp/esqueleto/pull/333)
+    - [#339](https://github.com/bitemyapp/esqueleto/pull/333)
       - Add `forUpdateOf`, `forShareOf` locking kinds for postgres
 
 3.5.8.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.9.0
+=======
+- @josephsumabat
+    - [#333](https://github.com/bitemyapp/esqueleto/pull/333)
+      - Add `forUpdateOf`, `forShareOf` locking kinds for postgres
+
 3.5.8.1
 =======
 - @belevy

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -83,6 +83,7 @@ module Database.Esqueleto {-# WARNING "This module will switch over to the Exper
   , OrderBy
   , DistinctOn
   , LockingKind(..)
+  , LockableEntity(..)
   , SqlString
     -- ** Joins
   , InnerJoin(..)

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -174,6 +174,7 @@ module Database.Esqueleto.Experimental
     , OrderBy
     , DistinctOn
     , LockingKind(..)
+    , LockableEntity(..)
     , SqlString
 
       -- ** Joins

--- a/src/Database/Esqueleto/Experimental/From/Join.hs
+++ b/src/Database/Esqueleto/Experimental/From/Join.hs
@@ -27,21 +27,6 @@ import Database.Esqueleto.Internal.Internal hiding
        (From(..), from, fromJoin, on)
 import GHC.TypeLits
 
--- | A left-precedence pair. Pronounced \"and\". Used to represent expressions
--- that have been joined together.
---
--- The precedence behavior can be demonstrated by:
---
--- @
--- a :& b :& c == ((a :& b) :& c)
--- @
---
--- See the examples at the beginning of this module to see how this
--- operator is used in 'JOIN' operations.
-data (:&) a b = a :& b
-    deriving (Eq, Show)
-infixl 2 :&
-
 instance (ToMaybe a, ToMaybe b) => ToMaybe (a :& b) where
     type ToMaybeT (a :& b) = (ToMaybeT a :& ToMaybeT b)
     toMaybe (a :& b) = (toMaybe a :& toMaybe b)

--- a/src/Database/Esqueleto/Experimental/From/Join.hs
+++ b/src/Database/Esqueleto/Experimental/From/Join.hs
@@ -13,6 +13,9 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Database.Esqueleto.Experimental.From.Join
+  (module Database.Esqueleto.Experimental.From.Join
+  , (:&)
+  )
     where
 
 import Data.Bifunctor (first)

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -53,6 +53,7 @@ import qualified Data.Conduit as C
 import qualified Data.Conduit.List as CL
 import qualified Data.HashSet as HS
 import Data.Kind (Type)
+import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import qualified Data.Monoid as Monoid
 import Data.Proxy (Proxy(..))
@@ -75,7 +76,6 @@ import Database.Persist.Sql.Util
 import Database.Persist.SqlBackend
 import GHC.Records
 import Text.Blaze.Html (Html)
-import qualified Data.List as List
 
 -- | (Internal) Start a 'from' query with an entity. 'from'
 -- does two kinds of magic using 'fromStart', 'fromJoin' and
@@ -2094,7 +2094,7 @@ instance Semigroup LockingClause where
   (<>) (GeneralLockingClause gleft) (GeneralLockingClause gright)  =
     Maybe.maybe mempty GeneralLockingClause
       (Monoid.getLast $ Monoid.Last (Just gleft) <> Monoid.Last (Just gright))
-  
+
   (<>) gleft@(GeneralLockingClause _) (PostgresLockingClauses _)  = gleft
   (<>) (PostgresLockingClauses _) gright@(GeneralLockingClause _) = gright
   (<>) mleft NoLockingClause = mleft

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1431,7 +1431,7 @@ infixl 2 :&
 --
 -- @since 2.2.7
 data LockingKind
-   = ForUpdate
+    = ForUpdate
       -- ^ @FOR UPDATE@ syntax.  Supported by MySQL, Oracle and
       -- PostgreSQL.
       --

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1448,7 +1448,7 @@ data LockingKind where
 
 -- | Postgres specific locking, used only internally
 --
--- @since 3.5.8.0
+-- @since 3.5.9.0
 data PostgresLockingKind where
   PostgresLockingKind :: PostgresRowLevelLockStrength -> OnLockedBehavior -> PostgresLockingKind
 
@@ -1485,12 +1485,12 @@ data OnLockedBehavior =
   -- ^ @NOWAIT@ syntax locking behaviour.
   --  query excutes immediately failing 
   -- 
-  -- @since 3.5.8.0
+  -- @since 3.5.9.0
   NoWait
   -- ^ @SKIP LOCKED@ syntax locking behaviour.
   --  query skips locked rows
   -- 
-  -- @since 3.5.8.0
+  -- @since 3.5.9.0
     | SkipLocked
     | Wait
     deriving (Ord, Eq, Show)

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1,18 +1,19 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeApplications #-}
-{-# language DerivingStrategies, GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -26,8 +27,6 @@
 -- tracker so we can safely support it.
 module Database.Esqueleto.Internal.Internal where
 
-import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NEL
 import Control.Applicative ((<|>))
 import Control.Arrow (first, (***))
 import Control.Exception (Exception, throw, throwIO)
@@ -38,6 +37,8 @@ import Control.Monad.Trans.Resource (MonadResource, release)
 import Data.Acquire (Acquire, allocateAcquire, with)
 import Data.Int (Int64)
 import Data.List (intersperse)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Maybe as Maybe
 #if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
@@ -46,9 +47,11 @@ import qualified Control.Monad.Trans.Reader as R
 import qualified Control.Monad.Trans.State as S
 import qualified Control.Monad.Trans.Writer as W
 import qualified Data.ByteString as B
+import Data.Coerce (coerce)
 import qualified Data.Conduit as C
 import qualified Data.Conduit.List as CL
 import qualified Data.HashSet as HS
+import Data.Kind (Type)
 import qualified Data.Map.Strict as Map
 import qualified Data.Monoid as Monoid
 import Data.Proxy (Proxy(..))
@@ -60,18 +63,17 @@ import qualified Data.Text.Lazy.Builder as TLB
 import Data.Typeable (Typeable)
 import Database.Esqueleto.Internal.ExprParser (TableAccess(..), parseOnExpr)
 import Database.Esqueleto.Internal.PersistentImport
-import Database.Persist.SqlBackend
+import Database.Persist (EntityNameDB(..), FieldNameDB(..), SymbolToField(..))
 import qualified Database.Persist
 import Database.Persist.Sql.Util
        ( entityColumnCount
-       , keyAndEntityColumnNames
        , isIdField
+       , keyAndEntityColumnNames
        , parseEntityValues
        )
-import Text.Blaze.Html (Html)
-import Data.Coerce (coerce)
-import Data.Kind (Type)
+import Database.Persist.SqlBackend
 import GHC.Records
+import Text.Blaze.Html (Html)
 
 -- | (Internal) Start a 'from' query with an entity. 'from'
 -- does two kinds of magic using 'fromStart', 'fromJoin' and
@@ -1405,25 +1407,48 @@ data Insertion a
 -- are no guarantees that they will behave the same.
 --
 -- @since 2.2.7
-data LockingKind
-    = ForUpdate
+data LockingKind where
+    ForUpdate :: LockingKind
       -- ^ @FOR UPDATE@ syntax.  Supported by MySQL, Oracle and
       -- PostgreSQL.
       --
       -- @since 2.2.7
-    | ForUpdateSkipLocked
+    ForUpdateSkipLocked :: LockingKind
       -- ^ @FOR UPDATE SKIP LOCKED@ syntax.  Supported by MySQL, Oracle and
       -- PostgreSQL.
       --
       -- @since 2.2.7
-    | ForShare
+    ForShare :: LockingKind
       -- ^ @FOR SHARE@ syntax.  Supported by PostgreSQL.
       --
       -- @since 2.2.7
-    | LockInShareMode
+    LockInShareMode :: LockingKind
       -- ^ @LOCK IN SHARE MODE@ syntax.  Supported by MySQL.
       --
       -- @since 2.2.7
+    ForUpdateOfSkipLocked :: [LockableEntity] -> LockingKind
+      -- ^ @FOR UPDATE OF tablename SKIP LOCKED@ syntax. Supported by MySQL, and PostgreSQL
+      --
+      -- @since 3.6.0.0
+
+-- | Wraps table type entities for use with LockingKind. 
+--
+-- Example use:
+--
+-- @
+-- select $ do
+--     (p :& bp) <- from $ 
+--         table @Person
+--         `innerJoin` table @BlogPost
+--             `on` do
+--                 \(p :& bp) -> p ^. PersonId ==. b ^. BlogPostAuthorId
+--     forUpdateOfSkipLocked [LockableEntity p,LockableEntity b]
+--     return p
+-- @
+--
+-- @since 3.6.0.0
+data LockableEntity where
+  LockableEntity :: PersistEntity val => (SqlExpr (Entity val)) -> LockableEntity
 
 -- | Phantom class of data types that are treated as strings by the
 -- RDBMS.  It has no methods because it's only used to avoid type
@@ -2820,7 +2845,7 @@ toRawSql mode (conn, firstIdentState) query =
         , makeHaving     info havingClause
         , makeOrderBy    info orderByClauses
         , makeLimit      info limitClause
-        , makeLocking         lockingClause
+        , makeLocking    info lockingClause
         ]
 
 -- | Renders a 'SqlQuery' into a 'Text' value along with the list of
@@ -3053,13 +3078,17 @@ makeLimit (conn, _) (Limit ml mo) =
         v = maybe 0 fromIntegral
     in (TLB.fromText limitRaw, mempty)
 
-makeLocking :: LockingClause -> (TLB.Builder, [PersistValue])
-makeLocking = flip (,) [] . maybe mempty toTLB . Monoid.getLast
-  where
-    toTLB ForUpdate           = "\nFOR UPDATE"
-    toTLB ForUpdateSkipLocked = "\nFOR UPDATE SKIP LOCKED"
-    toTLB ForShare            = "\nFOR SHARE"
-    toTLB LockInShareMode     = "\nLOCK IN SHARE MODE"
+makeLocking :: IdentInfo -> LockingClause -> (TLB.Builder, [PersistValue])
+makeLocking info lockingClause =
+  case Monoid.getLast lockingClause of
+    Just ForUpdate           -> ("\nFOR UPDATE", [])
+    Just ForUpdateSkipLocked -> ("\nFOR UPDATE SKIP LOCKED", [])
+    Just ForShare            -> ("\nFOR SHARE", [])
+    Just LockInShareMode     -> ("\nLOCK IN SHARE MODE", [])
+    Just (ForUpdateOfSkipLocked rawNames) ->
+      let names = uncommas' $ (\(LockableEntity (ERaw _ f)) -> (f Never info)) <$> rawNames in
+      first (\n -> "\nFOR UPDATE OF " <> n <> " SKIP LOCKED") names
+    Nothing -> mempty
 
 parens :: TLB.Builder -> TLB.Builder
 parens b = "(" <> (b <> ")")

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -3193,14 +3193,9 @@ makeLocking info (PostgresLockingClause (PostgresLockingKind rowStrength onLockB
     makeLockingBehavior :: OnLockedBehavior -> (TLB.Builder, [PersistValue])
     makeLockingBehavior NoWait = plain "NO WAIT"
     makeLockingBehavior SkipLocked = plain "SKIP LOCKED"
+    makeLockingBehavior Wait = plain ""
     plain v = (v,[])
 makeLocking _ NoLockingClause = mempty
-
-
---    Just (ForUpdateOfSkipLocked rawNames) ->
---      let names = uncommas' $ (\(LockableEntity1 (ERaw _ f)) -> (f Never info)) <$> rawNames in
---      first (\n -> "\nFOR UPDATE OF " <> n <> " SKIP LOCKED") names
---    Nothing -> mempty
 
 parens :: TLB.Builder -> TLB.Builder
 parens b = "(" <> (b <> ")")

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -409,7 +409,7 @@ locking kind = putLocking $ GeneralLockingClause kind
 
 -- | Helper to add a any type of locking clause to a query
 --
--- @since 3.5.9.0
+-- @since 3.5.9.2
 putLocking :: LockingClause -> SqlQuery ()
 putLocking clause = Q $ W.tell mempty { sdLockingClause = clause }
 
@@ -1452,7 +1452,7 @@ data LockingKind
 
 -- | Postgres specific locking, used only internally
 --
--- @since 3.5.9.0
+-- @since 3.5.9.2
 data PostgresLockingKind =
   PostgresLockingKind
     {
@@ -1475,17 +1475,17 @@ data OnLockedBehavior =
   -- ^ @NOWAIT@ syntax locking behaviour.
   --  query excutes immediately failing on locked rows
   --
-  -- @since 3.5.9.0
+  -- @since 3.5.9.2
     | SkipLocked
   -- ^ @SKIP LOCKED@ syntax locking behaviour.
   --  query skips locked rows
   --
-  -- @since 3.5.9.0
+  -- @since 3.5.9.2
     | Wait
   -- ^ default locking behaviour.
   --  query will wait on locked rows
   --
-  -- @since 3.5.9.0
+  -- @since 3.5.9.2
     deriving (Ord, Eq, Show)
 
 

--- a/src/Database/Esqueleto/Legacy.hs
+++ b/src/Database/Esqueleto/Legacy.hs
@@ -84,6 +84,7 @@ module Database.Esqueleto.Legacy
   , OrderBy
   , DistinctOn
   , LockingKind(..)
+  , LockableEntity(..)
   , SqlString
     -- ** Joins
   , InnerJoin(..)

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -466,12 +466,13 @@ wait = Wait
 -- @since 3.5.9.0
 forUpdateOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forUpdateOf lockableEntities onLockedBehavior =
-  putLocking $ PostgresLockingClause (PostgresLockingKind PostgresForUpdate (Just $ Of lockableEntities) onLockedBehavior)
+  putLocking $ PostgresLockingClauses [PostgresLockingKind PostgresForUpdate (Just $ LockingOfClause lockableEntities) onLockedBehavior]
 
 -- | `FOR SHARE OF` syntax for postgres locking
 -- allows locking of specific tables
 --
 -- @since 3.5.9.0
+
 forShareOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forShareOf lockableEntities onLockedBehavior =
-  putLocking $ PostgresLockingClause (PostgresLockingKind PostgresForUpdate (Just $ Of lockableEntities) onLockedBehavior)
+  putLocking $ PostgresLockingClauses [PostgresLockingKind PostgresForShare (Just $ LockingOfClause lockableEntities) onLockedBehavior]

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -55,7 +55,8 @@ import qualified Data.Text.Lazy as TL
 import Data.Time.Clock (UTCTime)
 import qualified Database.Esqueleto.Experimental as Ex
 import Database.Esqueleto.Internal.Internal hiding (random_)
-import Database.Esqueleto.Internal.PersistentImport hiding (upsert, upsertBy, uniqueFields)
+import Database.Esqueleto.Internal.PersistentImport hiding
+       (uniqueFields, upsert, upsertBy)
 import Database.Persist.SqlBackend
 
 -- | (@random()@) Split out into database specific modules

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -443,27 +443,27 @@ values exprs = Ex.From $ do
 -- `NO WAIT` syntax for postgres locking
 -- error will be thrown if locked rows are attempted to be selected
 --
--- @since 3.5.8.0
+-- @since 3.5.9.0
 noWait :: OnLockedBehavior
 noWait = NoWait
 
 -- `SKIP LOCKED` syntax for postgres locking
 -- locked rows will be skipped
 --
--- @since 3.5.8.0
+-- @since 3.5.9.0
 skipLocked :: OnLockedBehavior
 skipLocked = SkipLocked
 
 -- default behaviour of postgres locks. will attempt to wait for locks to expire
 --
--- @since 3.5.8.0
+-- @since 3.5.9.0
 wait :: OnLockedBehavior
 wait = Wait
 
 -- | `FOR UPDATE OF` syntax for postgres locking
 -- allows locking of specific tables
 --
--- @since 3.5.8.0
+-- @since 3.5.9.0
 forUpdateOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forUpdateOf lockableEntities onLockedBehavior =
   putLocking $ PostgresLockingClause (PostgresLockingKind (PostgresForUpdate $ Just $ Of lockableEntities) onLockedBehavior)
@@ -471,7 +471,7 @@ forUpdateOf lockableEntities onLockedBehavior =
 -- | `FOR SHARE OF` syntax for postgres locking
 -- allows locking of specific tables
 --
--- @since 3.5.8.0
+-- @since 3.5.9.0
 forShareOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forShareOf lockableEntities onLockedBehavior =
   putLocking $ PostgresLockingClause (PostgresLockingKind (PostgresForUpdate $ Just $ Of lockableEntities) onLockedBehavior)

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -466,7 +466,7 @@ wait = Wait
 -- @since 3.5.9.0
 forUpdateOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forUpdateOf lockableEntities onLockedBehavior =
-  putLocking $ PostgresLockingClause (PostgresLockingKind (PostgresForUpdate $ Just $ Of lockableEntities) onLockedBehavior)
+  putLocking $ PostgresLockingClause (PostgresLockingKind PostgresForUpdate (Just $ Of lockableEntities) onLockedBehavior)
 
 -- | `FOR SHARE OF` syntax for postgres locking
 -- allows locking of specific tables
@@ -474,4 +474,4 @@ forUpdateOf lockableEntities onLockedBehavior =
 -- @since 3.5.9.0
 forShareOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forShareOf lockableEntities onLockedBehavior =
-  putLocking $ PostgresLockingClause (PostgresLockingKind (PostgresForUpdate $ Just $ Of lockableEntities) onLockedBehavior)
+  putLocking $ PostgresLockingClause (PostgresLockingKind PostgresForUpdate (Just $ Of lockableEntities) onLockedBehavior)

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -441,38 +441,38 @@ values exprs = Ex.From $ do
             , params
             )
 
--- `NO WAIT` syntax for postgres locking
+-- | `NO WAIT` syntax for postgres locking
 -- error will be thrown if locked rows are attempted to be selected
 --
--- @since 3.5.9.0
+-- @since 3.5.9.2
 noWait :: OnLockedBehavior
 noWait = NoWait
 
--- `SKIP LOCKED` syntax for postgres locking
+-- | `SKIP LOCKED` syntax for postgres locking
 -- locked rows will be skipped
 --
--- @since 3.5.9.0
+-- @since 3.5.9.2
 skipLocked :: OnLockedBehavior
 skipLocked = SkipLocked
 
--- default behaviour of postgres locks. will attempt to wait for locks to expire
+-- | default behaviour of postgres locks. will attempt to wait for locks to expire
 --
--- @since 3.5.9.0
+-- @since 3.5.9.2
 wait :: OnLockedBehavior
 wait = Wait
 
 -- | `FOR UPDATE OF` syntax for postgres locking
--- allows locking of specific tables
+-- allows locking of specific tables with an update lock in a view or join
 --
--- @since 3.5.9.0
+-- @since 3.5.9.2
 forUpdateOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forUpdateOf lockableEntities onLockedBehavior =
   putLocking $ PostgresLockingClauses [PostgresLockingKind PostgresForUpdate (Just $ LockingOfClause lockableEntities) onLockedBehavior]
 
 -- | `FOR SHARE OF` syntax for postgres locking
--- allows locking of specific tables
+-- allows locking of specific tables with a share lock in a view or join
 --
--- @since 3.5.9.0
+-- @since 3.5.9.2
 
 forShareOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forShareOf lockableEntities onLockedBehavior =

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -27,6 +27,7 @@ module Database.Esqueleto.PostgreSQL
     , upsertBy
     , insertSelectWithConflict
     , insertSelectWithConflictCount
+    , forUpdateOfSkipLocked
     , filterWhere
     , values
     -- * Internal
@@ -434,3 +435,6 @@ values exprs = Ex.From $ do
             <> "(" <> TLB.fromLazyText colsAliases <> ")"
             , params
             )
+
+forUpdateOfSkipLocked :: [LockableEntity] -> SqlQuery ()
+forUpdateOfSkipLocked = locking . ForUpdateOfSkipLocked

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -85,12 +85,12 @@ import qualified Data.Text.Internal.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TLB
 import qualified Database.Esqueleto.Internal.ExprParser as P
 import qualified Database.Esqueleto.Internal.Internal as EI
-import qualified UnliftIO.Resource as R
 import Database.Esqueleto.PostgreSQL as EP
 import Database.Persist.Class.PersistEntity
+import qualified UnliftIO.Resource as R
 
-import Common.Test.Select
 import Common.Record (testDeriveEsqueletoRecord)
+import Common.Test.Select
 
 -- Test schema
 -- | this could be achieved with S.fromList, but not all lists
@@ -1678,7 +1678,7 @@ testLocking = do
             generalLockingQuery= do
               p <- Experimental.from $ table @Person
               locking ForUpdate
- 
+
         conn <- ask
         let res1 = toText conn multipleLockingQueryGeneralFirst
             res2 = toText conn multipleLockingQueryGeneralFirst

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1701,6 +1701,27 @@ testLocking = do
         liftIO $ print res1
         asserting $ res1 `shouldBe` expected
         asserting $ res2 `shouldBe` expected
+    
+    itDb "takes the union of equal postgres table specific locks" $ do
+        let twoUpdateQuery = do
+                (p :& bp) <-
+                  Experimental.from $ table @Person
+                    `Experimental.innerJoin` table @BlogPost
+                    `Experimental.on` (\(p :& bp) -> p ^. PersonId ==. bp ^. BlogPostAuthorId)
+                EP.forUpdateOf p EP.skipLocked
+                EP.forUpdateOf bp EP.skipLocked
+            expectedQuery = do
+                (p :& bp) <-
+                  Experimental.from $ table @Person
+                    `Experimental.innerJoin` table @BlogPost
+                    `Experimental.on` (\(p :& bp) -> p ^. PersonId ==. bp ^. BlogPostAuthorId)
+                EP.forUpdateOf (p :& bp) EP.skipLocked
+
+        conn <- ask
+        let res1 = toText conn twoUpdateQuery
+            res2 = toText conn expectedQuery
+        liftIO $ print res1
+        asserting $ res1 `shouldBe` res2
 
 
 testCountingRows :: SpecDb

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -12,10 +12,11 @@
 module PostgreSQL.Test where
 
 import Control.Arrow ((&&&))
+import Control.Concurrent (forkIO)
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Control.Monad.Logger (runNoLoggingT, runStderrLoggingT)
-import Control.Monad.Trans.Reader (ReaderT, ask, mapReaderT)
+import Control.Monad.Trans.Reader (ReaderT, ask, mapReaderT, runReaderT)
 import qualified Control.Monad.Trans.Resource as R
 import Data.Aeson hiding (Value)
 import qualified Data.Aeson as A (Value)
@@ -45,6 +46,7 @@ import Database.Persist.Postgresql (createPostgresqlPool, withPostgresqlConn)
 import Database.PostgreSQL.Simple (ExecStatus(..), SqlError(..))
 import System.Environment
 import Test.Hspec
+import Test.Hspec.Core.Spec (sequential)
 import Test.Hspec.QuickCheck
 
 import Common.Test
@@ -1227,6 +1229,169 @@ testCommonTableExpressions = do
             pure res
         asserting $ vals `shouldBe` fmap Value [2..11]
 
+testPostgresqlLocking :: SpecDb
+testPostgresqlLocking =
+    describe "For update skip locked locking" $ sequential $ do
+      let mkInitialStateForLockingTest connection =
+            flip runSqlPool connection $ do
+                  p1k <- insert p1
+                  p2k <- insert p2
+                  p3k <- insert p3
+                  blogPosts <- mapM insert'
+                    [ BlogPost "A" p1k
+                    , BlogPost "B" p2k
+                    , BlogPost "C" p3k ]
+                  pure ([p1k, p2k, p3k], entityKey <$> blogPosts)
+          cleanupLockingTest connection (personKeys, blogPostKeys) =
+              flip runSqlPool connection $ do
+                void $ forM_ blogPostKeys P.delete
+                void $ forM_ personKeys P.delete
+      aroundWith (\testAction connection -> do
+        bracket (mkInitialStateForLockingTest connection) (cleanupLockingTest connection) $ \(personKeys, blogPostKeys) ->
+            testAction (connection, personKeys, blogPostKeys)
+        ) $ do
+              it "skips locked rows for a locking select" $ \(connection, personKeys, blogPostKeys) -> do
+                    waitMainThread <- newEmptyMVar
+
+                    let sideThread :: IO Expectation
+                        sideThread = do
+                          flip runSqlPool connection $ do
+
+                            _ <- takeMVar waitMainThread
+                            nonLockedRowsNonSpecified <-
+                              select $ do
+                                  p <- Experimental.from $ table @Person
+                                  locking (ForUpdateSkipLocked)
+                                  return p
+
+                            nonLockedRowsSpecifiedTable <-
+                              select $ do
+                                from $ \(p `LeftOuterJoin` b) -> do
+                                  on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                  EP.forUpdateOfSkipLocked [LockableEntity p]
+                                  return p
+
+                            nonLockedRowsSpecifyAllTables <-
+                              select $ do
+                                from $ \(p `InnerJoin` b) -> do
+                                  on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                  EP.forUpdateOfSkipLocked [LockableEntity p,LockableEntity b]
+                                  return p
+
+                            pure $ do
+                                  nonLockedRowsNonSpecified `shouldBe` []
+                                  nonLockedRowsSpecifiedTable `shouldBe` []
+                                  nonLockedRowsSpecifyAllTables `shouldBe` []
+
+                    withAsync sideThread $ \sideThreadAsync -> do
+                      void $ flip runSqlPool connection $ do
+                        void $ select $ do
+                              person <- Experimental.from $ table @Person
+                              locking (ForUpdate)
+                              pure $ person ^. PersonId
+
+                        _ <- putMVar waitMainThread ()
+                        sideThreadAsserts <- wait sideThreadAsync
+                        nonLockedRowsAfterUpdate <- select $ do
+                                              from $ \(p `LeftOuterJoin` b) -> do
+                                                on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                                EP.forUpdateOfSkipLocked [LockableEntity p]
+                                                return p
+
+                        asserting $ sideThreadAsserts
+                        asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
+
+              it "skips locked rows for a subselect update" $ \(connection, personKeys, blogPostKeys)-> do
+                  waitMainThread <- newEmptyMVar
+
+                  let sideThread :: IO Expectation
+                      sideThread =
+                            flip runSqlPool connection $ do
+                              liftIO $ takeMVar waitMainThread
+
+                              nonLockedRowsSpecifiedTable <-
+                                select $ do
+                                   from $ \(p `LeftOuterJoin` b) -> do
+                                     on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                     EP.forUpdateOfSkipLocked [LockableEntity p]
+                                     return p
+
+                              pure $ length nonLockedRowsSpecifiedTable `shouldBe` 2
+
+                  withAsync sideThread $ \sideThreadAsync -> do
+                    void $ flip runSqlPool connection $ do
+                      update $ \p -> do
+                            set p [ PersonName =. val "ChangedName" ]
+                            where_ $ p ^. PersonId
+                              `in_` (subList_select $ do
+                                        person <- Experimental.from $ table @Person
+                                        limit 1
+                                        locking (ForUpdate)
+                                        pure $ person ^. PersonId)
+
+                      liftIO $ putMVar waitMainThread ()
+                      sideThreadAsserts <- wait sideThreadAsync
+                      nonLockedRowsAfterUpdate <- select $ do
+                                            from $ \(p `LeftOuterJoin` b) -> do
+                                              on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                              EP.forUpdateOfSkipLocked [LockableEntity p]
+                                              return p
+
+                      asserting sideThreadAsserts
+                      asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
+
+              it "skips locked rows for a subselect join update" $ \(connection, personKeys, blogPostKeys) -> do
+                  waitMainThread <- newEmptyMVar
+
+                  let sideThread :: IO Expectation
+                      sideThread =
+                            flip runSqlPool connection $ do
+                                liftIO $ takeMVar waitMainThread
+                                lockedRows <-
+                                  select $ do
+                                    from $ \(p `LeftOuterJoin` b) -> do
+                                      on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                      where_ (b ^. BlogPostTitle ==. val "A")
+                                      EP.forUpdateOfSkipLocked [LockableEntity p]
+                                      return p
+
+                                nonLockedRows <-
+                                  select $ do
+                                    from $ \(p `LeftOuterJoin` b) -> do
+                                      on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                      EP.forUpdateOfSkipLocked [LockableEntity p]
+                                      return p
+
+                                pure $ do
+                                    lockedRows `shouldBe` []
+                                    length nonLockedRows `shouldBe` 2
+
+                  withAsync sideThread $ \sideThreadAsync -> do
+                    void $ flip runSqlPool connection $ do
+                      update $ \p -> do
+                            set p [ PersonName =. val "ChangedName" ]
+                            where_ $ p ^. PersonId
+                              `in_` (subList_select $ do
+                                      (people :& blogPosts) <-
+                                          Experimental.from $ table @Person
+                                          `Experimental.leftJoin` table @BlogPost
+                                          `Experimental.on` (\(people :& blogPosts) ->
+                                                  just (people ^. PersonId) ==. blogPosts ?. BlogPostAuthorId)
+                                      where_ (blogPosts ?. BlogPostTitle ==. just (val "A"))
+                                      pure $ people ^. PersonId
+                                    )
+
+                      liftIO $ putMVar waitMainThread ()
+                      sideThreadAsserts <- wait sideThreadAsync
+                      nonLockedRowsAfterUpdate <- select $ do
+                                            from $ \(p `LeftOuterJoin` b) -> do
+                                              on (p ^. PersonId ==. b ^. BlogPostAuthorId)
+                                              EP.forUpdateOfSkipLocked [LockableEntity p]
+                                              return p
+
+                      asserting sideThreadAsserts
+                      asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
+
 -- Since lateral queries arent supported in Sqlite or older versions of mysql
 -- the test is in the Postgres module
 testLateralQuery :: SpecDb
@@ -1434,6 +1599,7 @@ spec = beforeAll mkConnectionPool $ do
         testLateralQuery
         testValuesExpression
         testSubselectAliasingBehavior
+        testPostgresqlLocking
 
 insertJsonValues :: SqlPersistT IO ()
 insertJsonValues = do

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -42,6 +42,7 @@ import Database.Esqueleto.PostgreSQL (random_)
 import qualified Database.Esqueleto.PostgreSQL as EP
 import Database.Esqueleto.PostgreSQL.JSON hiding ((-.), (?.), (||.))
 import qualified Database.Esqueleto.PostgreSQL.JSON as JSON
+import qualified Database.Persist.Class as P
 import Database.Persist.Postgresql (createPostgresqlPool, withPostgresqlConn)
 import Database.PostgreSQL.Simple (ExecStatus(..), SqlError(..))
 import System.Environment


### PR DESCRIPTION
**Context:**
Support `FOR UPDATE Of tablename` and `FOR SHARE OF tablename` syntax for Postgresql:

This allows a the `FOR UPDATE SKIP LOCKED`  behaviour when you have a `LEFT OUTER JOIN` with a nullable side.  Currently you will get the error:
```
FOR UPDATE cannot be applied to the nullable side of an outer join
```
The workaround currently using esqueleto is to do seperate queries and then join them manually if you want to select rows for an update while skipping locked rows (or to just do a raw query). I ran into this situation at work.

See: https://www.postgresql.org/docs/current/sql-select.html
namely:
```
FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE } [ OF table_name [, ...] ] [ NOWAIT | SKIP LOCKED ] [...] ]
```
also documented in MySQL: 
https://dev.mysql.com/doc/refman/8.0/en/select.html

```
    [FOR {UPDATE | SHARE}
        [OF tbl_name [, tbl_name] ...]
        [NOWAIT | SKIP LOCKED]
      | LOCK IN SHARE MODE]
    [into_option]
```
Usage example would be
```
select $ do
    (p :& bp) <- from $ 
        table @Person
        `innerJoin` table @BlogPost
            `on` do
                \(p :& b) -> p ^. PersonId ==. b ^. BlogPostAuthorId
                EP.forUpdateOf (p :& b) EP.skipLocked
    return p

```

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
