### PR TITLE
Add missing just to left join examples in the Haddocks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.9.1
+=======
+- @duplode
+    - [#363](https://github.com/bitemyapp/esqueleto/pull/363)
+      - Add missing `just` to left join examples in the Haddocks
+
 3.5.9.0
 =======
 - @9999years

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.9.0
+version:        3.5.9.1
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -354,8 +354,8 @@ import Database.Esqueleto.Experimental.ToMaybe
 --     from $ table \@Person
 --     \`leftJoin\` table \@BlogPost
 --     \`on\` (\\(people :& blogPosts) ->
---             people ^. PersonId ==. blogPosts ?. BlogPostAuthorId)
--- where_ (people ^. PersonAge >. val 18)
+--             just (people ^. PersonId) ==. blogPosts ?. BlogPostAuthorId)
+-- where_ (people ^. PersonAge >. just (val 18))
 -- pure (people, blogPosts)
 -- @
 --

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -339,8 +339,8 @@ import Database.Esqueleto.Experimental.ToMaybe
 -- @
 -- select $
 -- from $ \\(people \`LeftOuterJoin\` blogPosts) -> do
--- on (people ^. PersonId ==. blogPosts ?. BlogPostAuthorId)
--- where_ (people ^. PersonAge >. val 18)
+-- on (just (people ^. PersonId) ==. blogPosts ?. BlogPostAuthorId)
+-- where_ (people ^. PersonAge >. just (val 18))
 -- pure (people, blogPosts)
 -- @
 --

--- a/src/Database/Esqueleto/Experimental/From/Join.hs
+++ b/src/Database/Esqueleto/Experimental/From/Join.hs
@@ -230,7 +230,7 @@ crossJoinLateral lhs rhsFn = From $ do
 -- from $ table \@Person
 -- \`leftJoin\` table \@BlogPost
 -- \`on\` (\\(p :& bp) ->
---         p ^. PersonId ==. bp ?. BlogPostAuthorId)
+--         just (p ^. PersonId) ==. bp ?. BlogPostAuthorId)
 -- @
 --
 -- @since 3.5.0.0


### PR DESCRIPTION
This fixes #307, which has recently resurfaced on [a Stack Overflow question](https://stackoverflow.com/q/76234412/2751851). I believe the examples adjusted here were the only ones still missing `just`.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
