### PR TITLE
Name conflict dodges

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+3.5.10.0
+========
+- @parsonsmatt
+    - []()
+        - Add `isNothing_` and `groupBy_` to avoid name conflicts with
+          `Data.List` and `Data.Maybe`.
+
 3.5.9.0
 =======
 - @9999years

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 3.5.10.0
 ========
 - @parsonsmatt
-    - []()
+    - [#365](https://github.com/bitemyapp/esqueleto/pull/365)
         - Add `isNothing_` and `groupBy_` to avoid name conflicts with
           `Data.List` and `Data.Maybe`.
 

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,11 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-<<<<<<< HEAD
 version:        3.5.10.0
-=======
-version:        3.5.9.1
->>>>>>> master
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.9.0
+version:        3.5.10.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -65,6 +65,7 @@ module Database.Esqueleto.Experimental
     -- * The Normal Stuff
     , where_
     , groupBy
+    , groupBy_
     , orderBy
     , rand
     , asc
@@ -85,6 +86,7 @@ module Database.Esqueleto.Experimental
 
     , val
     , isNothing
+    , isNothing_
     , just
     , nothing
     , joinV

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -261,6 +261,13 @@ on expr = Q $ W.tell mempty { sdFromClause = [OnClause expr] }
 groupBy :: (ToSomeValues a) => a -> SqlQuery ()
 groupBy expr = Q $ W.tell mempty { sdGroupByClause = GroupBy $ toSomeValues expr }
 
+-- | An alias for 'groupBy' that avoids conflict with the term from "Data.List"
+-- 'Data.List.groupBy'.
+--
+-- @since 3.5.10.0
+groupBy_ :: (ToSomeValues a) => a -> SqlQuery ()
+groupBy_  = groupBy
+
 -- | @ORDER BY@ clause. See also 'asc' and 'desc'.
 --
 -- Multiple calls to 'orderBy' get concatenated on the final
@@ -659,6 +666,13 @@ isNothing v =
   where
     isNullExpr :: (TLB.Builder, a) -> (TLB.Builder, a)
     isNullExpr = first ((<> " IS NULL"))
+
+-- | An alias for 'isNothing' that avoids clashing with the function from
+-- "Data.Maybe" 'Data.Maybe.isNothing'.
+--
+-- @since 3.5.10.0
+isNothing_ :: PersistField typ => SqlExpr (Value (Maybe typ)) -> SqlExpr (Value Bool)
+isNothing_ = isNothing
 
 -- | Analogous to 'Just', promotes a value of type @typ@ into
 -- one of type @Maybe typ@.  It should hold that @'val' . Just


### PR DESCRIPTION
This PR adds `isNothing_`, `groupBy_`, and `updateE` as "non-conflicting" variants of the other esqueleto  functions. This helps avoid name conflicts and makes it easier to import `esqueleto` with other libraries.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
