### PR TITLE
Alias CTEs upon initialising

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.10.2
+========
+- @RikvanToor
+    - [#373](https://github.com/bitemyapp/esqueleto/pull/373)
+        - Fix name clashes when using CTEs multiple times
+
 3.5.10.1
 ========
 - @9999years

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.10.1
+version:        3.5.10.2
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
+++ b/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
@@ -53,7 +53,10 @@ with query = do
     let clause = CommonTableExpressionClause NormalCommonTableExpression ident (\info -> toRawSql SELECT info aliasedQuery)
     Q $ W.tell mempty{sdCteClause = [clause]}
     ref <- toAliasReference ident aliasedValue
-    pure $ From $ pure (ref, (\_ info -> (useIdent info ident, mempty)))
+    pure $ From $ do
+      newIdent <- newIdentFor (DBName "cte")
+      localRef <- toAliasReference newIdent ref
+      pure (localRef, (\_ info -> (useIdent info ident <> " AS " <> useIdent info newIdent, mempty)))
 
 -- | @WITH@ @RECURSIVE@ allows one to make a recursive subquery, which can
 -- reference itself. Like @WITH@, this is supported in most modern SQL engines.

--- a/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
+++ b/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
@@ -54,9 +54,10 @@ with query = do
     Q $ W.tell mempty{sdCteClause = [clause]}
     ref <- toAliasReference ident aliasedValue
     pure $ From $ do
-      newIdent <- newIdentFor (DBName "cte")
-      localRef <- toAliasReference newIdent ref
-      pure (localRef, (\_ info -> (useIdent info ident <> " AS " <> useIdent info newIdent, mempty)))
+        newIdent <- newIdentFor (DBName "cte")
+        localRef <- toAliasReference newIdent ref
+        let lh = useIdent info ident <> " AS " <> useIdent info newIdent
+        pure (localRef, (\_ info -> (lh, mempty)))
 
 -- | @WITH@ @RECURSIVE@ allows one to make a recursive subquery, which can
 -- reference itself. Like @WITH@, this is supported in most modern SQL engines.

--- a/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
+++ b/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
@@ -56,8 +56,8 @@ with query = do
     pure $ From $ do
         newIdent <- newIdentFor (DBName "cte")
         localRef <- toAliasReference newIdent ref
-        let lh = useIdent info ident <> " AS " <> useIdent info newIdent
-        pure (localRef, (\_ info -> (lh, mempty)))
+        let makeLH info = useIdent info ident <> " AS " <> useIdent info newIdent
+        pure (localRef, (\_ info -> (makeLH info, mempty)))
 
 -- | @WITH@ @RECURSIVE@ allows one to make a recursive subquery, which can
 -- reference itself. Like @WITH@, this is supported in most modern SQL engines.


### PR DESCRIPTION
Hello. :)

This PR fixes #372 by adding a fresh alias whenever a common table expression is used within a query.

As described in the issue, previously this Haskell code
```haskell
share [mkPersist sqlSettings] [persistLowerCase|
  A
    k Int
    v Int
    Primary k
  
  B
    k Int
    v Int
    Primary k
|]

q :: SqlQuery (SqlExpr (Value Int), SqlExpr (Value Int))
q = do
  bCte <- with $ do
    b <- from $ table @B
    return b
  
  a :& b1 :& b2 <- from $ table @A
    `innerJoin` bCte
    `on` (\(a :& b) -> a.k ==. b.k)
    `innerJoin` bCte
    `on` (\(a :& _ :& b2) -> a.k ==. b2.k)
  return (a.k, a.v +. b1.v +. b2.v)
```

would generated this SQL query
```sql
WITH `cte` AS (
  SELECT `b`.`k` AS `v_k`, `b`.`v` AS `v_v`
  FROM `b`
)

SELECT `a`.`k`,  ((`a`.`v` + `cte`.`v_v`) + `cte`.`v_v`)
FROM `a`
INNER JOIN `cte`
  ON `a`.`k` = `cte`.`v_k`
INNER JOIN `cte`
  ON `a`.`k` = `cte`.`v_k`;
```

which is invalid. After this PR, it instead generates this SQL query:
```sql
WITH `cte` AS (
  SELECT `b`.`k` AS `v_k`, `b`.`v` AS `v_v`
  FROM `b`
)

SELECT `a`.`k`,  ((`a`.`v` + `cte2`.`v_v`) + `cte3`.`v_v`)
FROM `a`
INNER JOIN `cte` AS `cte2`
  ON `a`.`k` = `cte2`.`v_k`
INNER JOIN `cte` AS `cte3`
  ON `a`.`k` = `cte3`.`v_k`
```

I'm not 100% satisfied with this, as the aliasing is only required when a single CTE is used multiple times in a single query, but my PR applies the aliasing at all times. I was not sure how to check for such a situation from within the context of the `with` function, so perhaps this PR can serve as a conversation about that. Thanks a lot!

---

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
