### PR TITLE
Fix Postgres syntax for NOWAIT

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.10.3
+========
+- @ttuegel
+    - [#377](https://github.com/bitemyapp/esqueleto/pull/377)
+        - Fix Postgres syntax for `noWait`
+
 3.5.10.2
 ========
 - @parsonsmatt

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.10.2
+version:        3.5.10.3
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -3257,7 +3257,7 @@ makeLocking info (PostgresLockingClauses clauses) =
             makeLockingStrength PostgresForShare = plain "FOR SHARE"
 
             makeLockingBehavior :: OnLockedBehavior -> (TLB.Builder, [PersistValue])
-            makeLockingBehavior NoWait = plain "NO WAIT"
+            makeLockingBehavior NoWait = plain "NOWAIT"
             makeLockingBehavior SkipLocked = plain "SKIP LOCKED"
             makeLockingBehavior Wait = plain ""
 

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -441,7 +441,7 @@ values exprs = Ex.From $ do
             , params
             )
 
--- | `NO WAIT` syntax for postgres locking
+-- | `NOWAIT` syntax for postgres locking
 -- error will be thrown if locked rows are attempted to be selected
 --
 -- @since 3.5.9.0

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1423,6 +1423,15 @@ testPostgresqlLocking = do
                             asserting sideThreadAsserts
                             asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
 
+    describe "noWait" $ do
+        itDb "doesn't crash" $ do
+            select $ do
+                t <- Experimental.from $ table @Person
+                EP.forUpdateOf t EP.noWait
+                pure t
+
+            asserting noExceptions
+
 -- Since lateral queries arent supported in Sqlite or older versions of mysql
 -- the test is in the Postgres module
 testLateralQuery :: SpecDb


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
