### PR TITLE
Generate `ToMaybe` in `deriveEsqueletoRecord`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+3.5.11.0
+========
+- @9999years, @halogenandtoast
+    - [#378](https://github.com/bitemyapp/esqueleto/pull/378)
+        - `ToMaybe` instances are now derived for records so you can now left
+          join in queries
+
 3.5.10.1
 ========
 - @9999years

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 - @9999years, @halogenandtoast
     - [#378](https://github.com/bitemyapp/esqueleto/pull/378)
         - `ToMaybe` instances are now derived for records so you can now left
-          join in queries
+          join them in queries
 
 3.5.10.1
 ========

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.10.1
+version:        3.5.11.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Record.hs
+++ b/src/Database/Esqueleto/Record.hs
@@ -757,7 +757,11 @@ toMaybeTDec RecordInfo {..} = do
   let binders = Nothing
       lhs = (ConT ''ToMaybeT) `AppT` (ConT sqlName)
       rhs = ConT sqlMaybeName
+#if MIN_VERSION_template_haskell(2,15,0)
   pure $ TySynInstD $ TySynEqn binders lhs rhs
+#else
+  pure $ TySynInstD $ TySynEqn lhs rhs
+#endif
 
 -- | Generates a `toMaybe value = ...` declaration for the given record.
 toMaybeDec :: RecordInfo -> Q Dec

--- a/src/Database/Esqueleto/Record.hs
+++ b/src/Database/Esqueleto/Record.hs
@@ -760,7 +760,7 @@ toMaybeTDec RecordInfo {..} = do
 #if MIN_VERSION_template_haskell(2,15,0)
   pure $ TySynInstD $ TySynEqn binders lhs rhs
 #else
-  pure $ TySynInstD $ TySynEqn lhs rhs
+  pure $ TySynInstD sqlName $ TySynEqn [lhs] rhs
 #endif
 
 -- | Generates a `toMaybe value = ...` declaration for the given record.

--- a/src/Database/Esqueleto/Record.hs
+++ b/src/Database/Esqueleto/Record.hs
@@ -877,7 +877,11 @@ sqlMaybeSelectProcessRowDec RecordInfo {..} = do
   colsName <- newName "columns"
 
   let
+#if MIN_VERSION_template_haskell(2,17,0)
     bodyExp = DoE Nothing
+#else
+    bodyExp = DoE
+#endif
         [ BindS joinedFields (AppE (VarE 'sqlSelectProcessRow) (VarE colsName))
         , NoBindS
             $ AppE (VarE 'pure) (

--- a/src/Database/Esqueleto/Record.hs
+++ b/src/Database/Esqueleto/Record.hs
@@ -754,13 +754,16 @@ makeToMaybeInstance info@RecordInfo {..} = do
 -- | Generates a `type ToMaybeT ... = ...` declaration for the given record.
 toMaybeTDec :: RecordInfo -> Q Dec
 toMaybeTDec RecordInfo {..} = do
-  let binders = Nothing
-      lhs = (ConT ''ToMaybeT) `AppT` (ConT sqlName)
-      rhs = ConT sqlMaybeName
+  pure $ mkTySynInstD ''ToMaybeT (ConT sqlName) (ConT sqlMaybeName)
+  where
+    mkTySynInstD className lhsArg rhs =
 #if MIN_VERSION_template_haskell(2,15,0)
-  pure $ TySynInstD $ TySynEqn binders lhs rhs
+        let binders = Nothing
+            lhs = ConT className `AppT` lhsArg
+        in
+            TySynInstD $ TySynEqn binders lhs rhs
 #else
-  pure $ TySynInstD sqlName $ TySynEqn [lhs] rhs
+       TySynInstD className $ TySynEqn [lhsArg] rhs
 #endif
 
 -- | Generates a `toMaybe value = ...` declaration for the given record.

--- a/test/Common/Record.hs
+++ b/test/Common/Record.hs
@@ -8,25 +8,34 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- Tests for `Database.Esqueleto.Record`.
 module Common.Record (testDeriveEsqueletoRecord) where
 
 import Common.Test.Import hiding (from, on)
+import Control.Monad.Trans.State.Strict (StateT(..), evalStateT)
+import Data.Bifunctor (first)
 import Data.List (sortOn)
+import Data.Maybe (catMaybes)
+import Data.Proxy (Proxy(..))
 import Database.Esqueleto.Experimental
+import Database.Esqueleto.Internal.Internal (SqlSelect(..))
 import Database.Esqueleto.Record
   ( DeriveEsqueletoRecordSettings(..)
   , defaultDeriveEsqueletoRecordSettings
   , deriveEsqueletoRecord
   , deriveEsqueletoRecordWith
+  , takeColumns
+  , takeMaybeColumns
   )
 
 data MyRecord =
@@ -111,6 +120,15 @@ myModifiedRecordQuery = do
       , myModifiedUserSql = user
       , myModifiedAddressSql = address
       }
+
+mySubselectRecordQuery :: SqlQuery (SqlExpr (Maybe (Entity Address)))
+mySubselectRecordQuery = do
+  _ :& record <- from $
+    table @User
+      `leftJoin`
+      myRecordQuery
+      `on` (do \(user :& record) -> just (user ^. #id) ==. record.myUser ?. #id)
+  pure $ record.myAddress
 
 testDeriveEsqueletoRecord :: SpecDb
 testDeriveEsqueletoRecord = describe "deriveEsqueletoRecord" $ do
@@ -208,7 +226,6 @@ testDeriveEsqueletoRecord = describe "deriveEsqueletoRecord" $ do
                           } -> addr1 == addr2 -- The keys should match.
                  _ -> False)
 
-
     itDb "can select user-modified records" $ do
         setup
         records <- select myModifiedRecordQuery
@@ -235,3 +252,64 @@ testDeriveEsqueletoRecord = describe "deriveEsqueletoRecord" $ do
                     , myModifiedAddress = Just (Entity addr2 Address {addressAddress = "30-50 Feral Hogs Rd"})
                     } -> addr1 == addr2 -- The keys should match.
                  _ -> False)
+
+    itDb "can left join on records" $ do
+        setup
+        records <- select $ do
+          from
+            ( table @User
+                `leftJoin` myRecordQuery `on` (do \(user :& record) -> just (user ^. #id) ==. record.myUser ?. #id)
+            )
+        let sortedRecords = sortOn (\(Entity _ user :& _) -> user.userName) records
+        liftIO $ sortedRecords !! 0
+          `shouldSatisfy`
+          (\case (_ :& Just (MyRecord {myName = "Rebecca", myAddress = Nothing})) -> True
+                 _ -> False)
+        liftIO $ sortedRecords !! 1
+          `shouldSatisfy`
+          (\case ( _ :& Just ( MyRecord { myName = "Some Guy"
+                                        , myAddress = (Just (Entity addr2 Address {addressAddress = "30-50 Feral Hogs Rd"}))
+                                        }
+                              )) -> True
+                 _ -> True)
+
+    itDb "can can handle joins on records with Nothing" $ do
+        setup
+        records <- select $ do
+          from
+            ( table @User
+                `leftJoin` myRecordQuery `on` (do \(user :& record) -> user ^. #address ==. record.myAddress ?. #id)
+            )
+        let sortedRecords = sortOn (\(Entity _ user :& _) -> user.userName) records
+        liftIO $ sortedRecords !! 0
+          `shouldSatisfy`
+          (\case (_ :& Nothing) -> True
+                 _ -> False)
+        liftIO $ sortedRecords !! 1
+          `shouldSatisfy`
+          (\case ( _ :& Just ( MyRecord { myName = "Some Guy"
+                                        , myAddress = (Just (Entity addr2 Address {addressAddress = "30-50 Feral Hogs Rd"}))
+                                        }
+                              )) -> True
+                 _ -> True)
+
+    itDb "can left join on nested records" $ do
+        setup
+        records <- select $ do
+          from
+            ( table @User
+                `leftJoin` myNestedRecordQuery
+                `on` (do \(user :& record) -> just (user ^. #id) ==. record.myRecord.myUser ?. #id)
+            )
+        let sortedRecords = sortOn (\(Entity _ user :& _) -> user.userName) records
+        liftIO $ sortedRecords !! 0
+          `shouldSatisfy`
+          (\case (_ :& Just (MyNestedRecord {myRecord = MyRecord {myName = "Rebecca", myAddress = Nothing}})) -> True
+                 _ -> False)
+        liftIO $ sortedRecords !! 1
+          `shouldSatisfy`
+          (\case ( _ :& Just ( MyNestedRecord { myRecord = MyRecord { myName = "Some Guy"
+                                                                    , myAddress = (Just (Entity addr2 Address {addressAddress = "30-50 Feral Hogs Rd"}))
+                                                                    }
+                                              })) -> True
+                 _ -> True)

--- a/test/Common/Record.hs
+++ b/test/Common/Record.hs
@@ -330,20 +330,20 @@ testDeriveEsqueletoRecord = describe "deriveEsqueletoRecord" $ do
                 `leftJoin` myNestedRecordQuery
                 `on` (do \(user :& record) -> just (user ^. #id) ==. record.myRecord.myUser ?. #id)
                 `leftJoin` myNestedRecordQuery
-                `on` (do \(user :& record1 :& record2) -> record1.myRecord.myUser ?. #id ==. record2.myRecord.myUser ?. #id)
+                `on` (do \(user :& record1 :& record2) -> record1.myRecord.myUser ?. #id !=. record2.myRecord.myUser ?. #id)
             )
         let sortedRecords = sortOn (\(Entity _ user :& _ :& _) -> user.userName) records
         liftIO $ sortedRecords !! 0
-          `shouldSatisfy`
-          (\case (_ :& _ :& Just (MyNestedRecord {myRecord = MyRecord {myName = "Rebecca", myAddress = Nothing}})) -> True
-                 _ -> False)
-        liftIO $ sortedRecords !! 1
           `shouldSatisfy`
           (\case ( _ :& _ :& Just ( MyNestedRecord { myRecord = MyRecord { myName = "Some Guy"
                                                                     , myAddress = (Just (Entity addr2 Address {addressAddress = "30-50 Feral Hogs Rd"}))
                                                                     }
                                               })) -> True
                  _ -> True)
+        liftIO $ sortedRecords !! 1
+          `shouldSatisfy`
+          (\case (_ :& _ :& Just (MyNestedRecord {myRecord = MyRecord {myName = "Rebecca", myAddress = Nothing}})) -> True
+                 _ -> False)
 
 #else
     it "is only supported in GHC 9.2 or above" $ \_ -> do

--- a/test/Common/Record.hs
+++ b/test/Common/Record.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -8,7 +9,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -17,6 +17,10 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+#if __GLASGOW_HASKELL__ >= 902
+{-# LANGUAGE OverloadedRecordDot #-}
+#endif
 
 -- Tests for `Database.Esqueleto.Record`.
 module Common.Record (testDeriveEsqueletoRecord) where
@@ -29,14 +33,16 @@ import Data.Maybe (catMaybes)
 import Data.Proxy (Proxy(..))
 import Database.Esqueleto.Experimental
 import Database.Esqueleto.Internal.Internal (SqlSelect(..))
-import Database.Esqueleto.Record
-  ( DeriveEsqueletoRecordSettings(..)
-  , defaultDeriveEsqueletoRecordSettings
-  , deriveEsqueletoRecord
-  , deriveEsqueletoRecordWith
-  , takeColumns
-  , takeMaybeColumns
-  )
+import Database.Esqueleto.Record (
+  DeriveEsqueletoRecordSettings(..),
+  defaultDeriveEsqueletoRecordSettings,
+  deriveEsqueletoRecord,
+  deriveEsqueletoRecordWith,
+  takeColumns,
+  takeMaybeColumns,
+ )
+
+#if __GLASGOW_HASKELL__ >= 902
 
 data MyRecord =
     MyRecord
@@ -313,3 +319,8 @@ testDeriveEsqueletoRecord = describe "deriveEsqueletoRecord" $ do
                                                                     }
                                               })) -> True
                  _ -> True)
+
+#else
+    it "is only supported in GHC 9.2 or above" $ \_ -> do
+        pending
+#endif

--- a/test/Common/Record.hs
+++ b/test/Common/Record.hs
@@ -42,8 +42,8 @@ import Database.Esqueleto.Record (
   takeMaybeColumns,
  )
 
-#if __GLASGOW_HASKELL__ >= 902
 
+#if __GLASGOW_HASKELL__ >= 902
 data MyRecord =
     MyRecord
         { myName :: Text
@@ -135,9 +135,12 @@ mySubselectRecordQuery = do
       myRecordQuery
       `on` (do \(user :& record) -> just (user ^. #id) ==. record.myUser ?. #id)
   pure $ record.myAddress
+#endif
 
 testDeriveEsqueletoRecord :: SpecDb
 testDeriveEsqueletoRecord = describe "deriveEsqueletoRecord" $ do
+#if __GLASGOW_HASKELL__ >= 902
+
     let setup :: MonadIO m => SqlPersistT m ()
         setup = do
           _ <- insert $ User { userAddress = Nothing, userName = "Rebecca" }


### PR DESCRIPTION
replaces #370

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

