### PR TITLE
Fix semantics of `not_` applied over `&&.` and `||.`

### DIFF
--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -717,16 +717,15 @@ countDistinct :: Num a => SqlExpr (Value typ) -> SqlExpr (Value a)
 countDistinct = countHelper "(DISTINCT " ")"
 
 not_ :: SqlExpr (Value Bool) -> SqlExpr (Value Bool)
-not_ v = ERaw noMeta $ \p info -> first ("NOT " <>) $ x p info
+not_ v = ERaw noMeta (const $ first ("NOT " <>) . x)
   where
-    x p info =
+    x info =
         case v of
             ERaw m f ->
                 if hasCompositeKeyMeta m then
                     throw (CompositeKeyErr NotError)
                 else
-                    let (b, vals) = f Never info
-                    in (parensM p b, vals)
+                    f Parens info
 
 (==.) :: PersistField typ => SqlExpr (Value typ) -> SqlExpr (Value typ) -> SqlExpr (Value Bool)
 (==.) = unsafeSqlBinOpComposite " = " " AND "

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -912,6 +912,13 @@ testSelectWhere = describe "select where_" $ do
                 asserting $ ret `shouldBe` [()]
 
     describe "when using not_" $ do
+        itDb "works for a single expression" $ do
+            ret <-
+                select $
+                pure $ not_ $ val True
+            asserting $ do
+                ret `shouldBe` [Value False]
+
         itDb "works for a simple example with (>.) [uses just . val]" $ do
             _   <- insert' p1
             _   <- insert' p2

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -878,16 +878,6 @@ testSelectWhere = describe "select where_" $ do
                return p
         asserting $ ret `shouldBe` [ p1e ]
 
-    itDb "works for a simple example with (>.) and not_ [uses just . val]" $ do
-        _   <- insert' p1
-        _   <- insert' p2
-        p3e <- insert' p3
-        ret <- select $
-               from $ \p -> do
-               where_ (not_ $ p ^. PersonAge >. just (val 17))
-               return p
-        asserting $ ret `shouldBe` [ p3e ]
-
     describe "when using between" $ do
         itDb "works for a simple example with [uses just . val]" $ do
             p1e  <- insert' p1
@@ -920,6 +910,44 @@ testSelectWhere = describe "select where_" $ do
                         ( val $ PointKey 1 2
                         , val $ PointKey 5 6 )
                 asserting $ ret `shouldBe` [()]
+
+    describe "when using not_" $ do
+        itDb "works for a simple example with (>.) [uses just . val]" $ do
+            _   <- insert' p1
+            _   <- insert' p2
+            p3e <- insert' p3
+            ret <- select $
+                   from $ \p -> do
+                   where_ (not_ $ p ^. PersonAge >. just (val 17))
+                   return p
+            asserting $ ret `shouldBe` [ p3e ]
+        itDb "works with (==.) and (||.)" $ do
+            _   <- insert' p1
+            _   <- insert' p2
+            p3e <- insert' p3
+            ret <- select $
+                   from $ \p -> do
+                   where_ (not_ $ p ^. PersonName ==. val "John" ||. p ^. PersonName ==. val "Rachel")
+                   return p
+            asserting $ ret `shouldBe` [ p3e ]
+        itDb "works with (>.), (<.) and (&&.) [uses just . val]" $ do
+            p1e <- insert' p1
+            _   <- insert' p2
+            _   <- insert' p3
+            ret <- select $
+                   from $ \p -> do
+                   where_ (not_ $ (p ^. PersonAge >. just (val 10)) &&. (p ^. PersonAge <. just (val 30)))
+                   return p
+            asserting $ ret `shouldBe` [ p1e ]
+        itDb "works with between [uses just . val]" $ do
+            _   <- insert' p1
+            _   <- insert' p2
+            p3e <- insert' p3
+            ret <- select $
+                   from $ \p -> do
+                   where_ (not_ $ (p ^. PersonAge) `between` (just $ val 20, just $ val 40))
+                   return p
+            asserting $ ret `shouldBe` [ p3e ]
 
     itDb "works with avg_" $ do
         _ <- insert' p1


### PR DESCRIPTION
This PR fixes #359 by always wrapping arguments to `not_` in parentheses when building SQL queries. Some tests combining `not_` with `&&.` and `||.` have also been added to `Common.Test`.

This is technically a breaking change: `not_ (x &&. y)` is no longer equivalent to `(not_ x) &&. y`, for example, although the equivalence is probably unintended.

---

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).
  - `stylish-haskell` fails to parse the `DEPRECATED` pragma for `sub_select` in `Database.Esqueleto.Internal.Internal`.

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
