### PR TITLE
Add Functor and Bifunctor instances for (:&)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.11.3
+========
+- @isomorpheme
+    - [#393](https://github.com/bitemyapp/esqueleto/pull/393)
+        - Add Functor and Bifunctor instances for `(:&)`
+
 3.5.11.2
 ========
 - @arguri

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.11.2
+version:        3.5.11.3
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -52,6 +52,7 @@ import Data.Semigroup
 import qualified Control.Monad.Trans.Reader as R
 import qualified Control.Monad.Trans.State as S
 import qualified Control.Monad.Trans.Writer as W
+import Data.Bifunctor (Bifunctor(bimap, second))
 import qualified Data.ByteString as B
 import Data.Coerce (coerce)
 import qualified Data.Conduit as C
@@ -1441,6 +1442,14 @@ data Insertion a
 data (:&) a b = a :& b
     deriving (Eq, Show)
 infixl 2 :&
+
+-- | @since 3.5.11.3
+instance Functor ((:&) a) where
+  fmap = second
+
+-- | @since 3.5.11.3
+instance Bifunctor (:&) where
+  bimap f g (x :& y) = f x :& g y
 
 -- | Different kinds of locking clauses supported by 'locking'.
 --


### PR DESCRIPTION
What it says on the tin - I had a need for these instances, and don't see a reason why they shouldn't exist.

----

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
