### PR TITLE
Add dependencies to nix packages in stack.yaml

### DIFF
--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -9,3 +9,6 @@ allow-newer: true
 extra-deps:
 - lift-type-0.1.0.1
 - persistent-2.14.0.2
+
+nix:
+  packages: [zlib, libmysqlclient, pcre, postgresql]

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -23,3 +23,6 @@ extra-deps:
   - scientific-0.3.6.2
   - text-1.2.3.0
   - unliftio-0.2.0.0
+
+nix:
+  packages: [zlib, libmysqlclient, pcre, postgresql]

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -13,3 +13,6 @@ extra-deps:
   - postgresql-libpq-0.9.4.2
   - postgresql-simple-0.6.1
   - transformers-0.5.5.2
+
+nix:
+  packages: [zlib, libmysqlclient, pcre, postgresql]

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -19,3 +19,6 @@ extra-deps:
   - lift-type-0.1.0.1
   - th-lift-instances-0.1.19
   - th-lift-0.8.2
+
+nix:
+  packages: [zlib, libmysqlclient, pcre, postgresql]

--- a/stack-8.8.yaml
+++ b/stack-8.8.yaml
@@ -10,3 +10,6 @@ extra-deps:
 - persistent-mysql-2.12.0.0
 - persistent-postgresql-2.12.0.0
 - persistent-sqlite-2.12.0.0
+
+nix:
+  packages: [zlib, libmysqlclient, pcre, postgresql]

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -9,3 +9,6 @@ allow-newer: true
 extra-deps:
 - lift-type-0.1.0.1
 - persistent-2.14.0.2
+
+nix:
+  packages: [zlib, libmysqlclient, pcre, postgresql]

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -12,3 +12,6 @@ extra-deps:
   - process-1.6.14.0
   - Cabal-3.6.3.0
   - unix-2.7.2.2
+
+nix:
+  packages: [zlib, libmysqlclient, pcre, postgresql]


### PR DESCRIPTION
This allowed me to build on NixOS with stack from nixpkgs. No changes intended when nix integration is not enabled.