### PR TITLE
Do not error on any AppT in sqlMaybeSelectProcessRowDec

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-3.5.14.0
+3.5.13.1
 ========
 - @csamak
     - [#405](https://github.com/bitemyapp/esqueleto/pull/405)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.14.0
+========
+- @csamak
+    - [#405](https://github.com/bitemyapp/esqueleto/pull/405)
+      - Fix a bug introduced in 3.5.12.0 where deriveEsqueletoRecord incorrectly errors
+
 3.5.13.0
 ========
 - @ac251

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.14.0
+version:        3.5.13.1
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.13.0
+version:        3.5.14.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Record.hs
+++ b/src/Database/Esqueleto/Record.hs
@@ -935,10 +935,8 @@ sqlMaybeSelectProcessRowDec RecordInfo {..} = do
       ]
   where
     wrapJust x = case x of
-      AppT (ConT ((==) ''Entity -> True)) _innerType -> id
       ((ConT ((==) ''Maybe -> True)) `AppT` _inner) -> AppE (ConE 'Just)
-      (ConT _) -> id
-      _ -> error $ show x
+      _ -> id
 
 -- | Generates the `sqlSelectColCount` declaration for an `SqlSelect` instance.
 sqlMaybeSelectColCountDec :: RecordInfo -> Q Dec


### PR DESCRIPTION
No need to be this restrictive in deriveEsqueletoRecord For example, AppT ListT _ and AppT (ConT _) _ are both fine but would throw an error here before this change.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
