### PR TITLE
Mattp/incorporate cte aliasing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+3.5.10.2
+========
+- @RikvanToor
+    - [#373](https://github.com/bitemyapp/esqueleto/pull/373)
+        - Fix name clashes when using CTEs multiple times
+
 3.5.10.1
 ========
 - @9999years

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.10.1
+version:        3.5.10.2
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -87,6 +87,7 @@ test-suite specs
     main-is: Spec.hs
     other-modules:
         Common.Test
+        Common.Test.CTE
         Common.Test.Models
         Common.Test.Import
         Common.Test.Select

--- a/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
+++ b/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
@@ -53,7 +53,10 @@ with query = do
     let clause = CommonTableExpressionClause NormalCommonTableExpression ident (\info -> toRawSql SELECT info aliasedQuery)
     Q $ W.tell mempty{sdCteClause = [clause]}
     ref <- toAliasReference ident aliasedValue
-    pure $ From $ pure (ref, (\_ info -> (useIdent info ident, mempty)))
+    pure $ From $ do
+      newIdent <- newIdentFor (DBName "cte")
+      localRef <- toAliasReference newIdent ref
+      pure (localRef, (\_ info -> (useIdent info ident <> " AS " <> useIdent info newIdent, mempty)))
 
 -- | @WITH@ @RECURSIVE@ allows one to make a recursive subquery, which can
 -- reference itself. Like @WITH@, this is supported in most modern SQL engines.

--- a/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
+++ b/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
@@ -54,9 +54,10 @@ with query = do
     Q $ W.tell mempty{sdCteClause = [clause]}
     ref <- toAliasReference ident aliasedValue
     pure $ From $ do
-      newIdent <- newIdentFor (DBName "cte")
-      localRef <- toAliasReference newIdent ref
-      pure (localRef, (\_ info -> (useIdent info ident <> " AS " <> useIdent info newIdent, mempty)))
+        newIdent <- newIdentFor (DBName "cte")
+        localRef <- toAliasReference newIdent ref
+        let lh = useIdent info ident <> " AS " <> useIdent info newIdent
+        pure (localRef, (\_ info -> (lh, mempty)))
 
 -- | @WITH@ @RECURSIVE@ allows one to make a recursive subquery, which can
 -- reference itself. Like @WITH@, this is supported in most modern SQL engines.

--- a/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
+++ b/src/Database/Esqueleto/Experimental/From/CommonTableExpression.hs
@@ -56,8 +56,8 @@ with query = do
     pure $ From $ do
         newIdent <- newIdentFor (DBName "cte")
         localRef <- toAliasReference newIdent ref
-        let lh = useIdent info ident <> " AS " <> useIdent info newIdent
-        pure (localRef, (\_ info -> (lh, mempty)))
+        let makeLH info = useIdent info ident <> " AS " <> useIdent info newIdent
+        pure (localRef, (\_ info -> (makeLH info, mempty)))
 
 -- | @WITH@ @RECURSIVE@ allows one to make a recursive subquery, which can
 -- reference itself. Like @WITH@, this is supported in most modern SQL engines.

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -91,6 +91,7 @@ import qualified UnliftIO.Resource as R
 
 import Common.Record (testDeriveEsqueletoRecord)
 import Common.Test.Select
+import qualified Common.Test.CTE as CTESpec
 
 -- Test schema
 -- | this could be achieved with S.fromList, but not all lists
@@ -2391,6 +2392,7 @@ tests =
         testLocking
         testOverloadedRecordDot
         testDeriveEsqueletoRecord
+        CTESpec.testCTE
 
 insert' :: ( Functor m
            , BaseBackend backend ~ PersistEntityBackend val

--- a/test/Common/Test/CTE.hs
+++ b/test/Common/Test/CTE.hs
@@ -1,0 +1,35 @@
+{-# language TypeApplications #-}
+
+module Common.Test.CTE where
+
+import Common.Test.Models
+import Common.Test.Import
+import Database.Persist.TH
+
+testCTE :: SpecDb
+testCTE = describe "CTE" $ do
+    itDb "can refer to the same CTE twice" $ do
+        let q :: SqlQuery (SqlExpr (Value Int), SqlExpr (Value Int))
+            q = do
+                bCte <- with $ do
+                    b <- from $ table @B
+                    pure b
+
+                a :& b1 :& b2 <- from $
+                    table @A
+                        `innerJoin` bCte
+                            `on` do
+                                \(a :& b) ->
+                                    a ^. AK ==. b ^. BK
+                        `innerJoin` bCte
+                            `on` do
+                                \(a :& _ :& b2) ->
+                                    a ^. AK ==. b2 ^. BK
+                pure (a ^. AK, a ^. AV +. b1 ^. BV +. b2 ^. BV)
+        insert_ $ A { aK = 1, aV = 2 }
+        insert_ $ B { bK = 1, bV = 3 }
+        ret <- select q
+        asserting $ do
+            ret `shouldMatchList`
+                [ (Value 1, Value (2 + 3 + 3))
+                ]

--- a/test/Common/Test/Models.hs
+++ b/test/Common/Test/Models.hs
@@ -182,6 +182,16 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
     address String
     deriving Show
     deriving Eq
+
+  A
+      k Int
+      v Int
+      Primary k
+
+  B
+      k Int
+      v Int
+      Primary k
 |]
 
 -- Unique Test schema

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1347,7 +1347,6 @@ testPostgresqlLocking = do
                                             EP.forUpdateOf p EP.skipLocked
                                             return p
 
-                                liftIO $ print nonLockedRowsSpecifiedTable
                                 pure $ length nonLockedRowsSpecifiedTable `shouldBe` 2
 
                     withAsync sideThread $ \sideThreadAsync -> do
@@ -1371,7 +1370,6 @@ testPostgresqlLocking = do
                                                     EP.forUpdateOf p EP.skipLocked
                                                     return p
 
-                            liftIO $ print nonLockedRowsAfterUpdate
                             asserting sideThreadAsserts
                             asserting $ length nonLockedRowsAfterUpdate `shouldBe` 3
 


### PR DESCRIPTION
This PR incorporates the changes from #373 along with the test. Fixes #372 

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
