### PR TITLE
Remove `Coercible` abiilty for `SqlExpr`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,10 @@
 3.6.0.0
 =======
 - @parsonsmatt
-    - []()
+    - [#413](https://github.com/bitemyapp/esqueleto/pull/413)
         - The ability to `coerce` `SqlExpr` was removed. Instead, use
-          `veryUnsafeCoerceSqlExpr`.
-
+          `veryUnsafeCoerceSqlExpr`. See the documentation on
+          `veryUnsafeCoerceSqlExpr` for safe use example.
 
 3.5.13.2
 ========

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+3.6.0.0
+=======
+- @parsonsmatt
+    - []()
+        - The ability to `coerce` `SqlExpr` was removed. Instead, use
+          `veryUnsafeCoerceSqlExpr`.
+
+
 3.5.13.2
 ========
 - @blujupiter32

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-3.5.13.2 (unreleased)
+3.5.13.2
 ========
 - @blujupiter32
     - [#379](https://github.com/bitemyapp/esqueleto/pull/379)

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -2,7 +2,7 @@ cabal-version: 1.12
 
 name:           esqueleto
 
-version:        3.5.13.2
+version:        3.6.0.0
 synopsis:       Type-safe EDSL for SQL queries on persistent backends.
 description:    @esqueleto@ is a bare bones, type-safe EDSL for SQL queries that works with unmodified @persistent@ SQL backends.  Its language closely resembles SQL, so you don't have to learn new concepts, just new syntax, and it's fairly easy to predict the generated SQL and optimize it for your backend. Most kinds of errors committed when writing SQL are caught as compile-time errors---although it is possible to write type-checked @esqueleto@ queries that fail at runtime.
                 .

--- a/src/Database/Esqueleto/Experimental/ToAliasReference.hs
+++ b/src/Database/Esqueleto/Experimental/ToAliasReference.hs
@@ -5,7 +5,6 @@
 module Database.Esqueleto.Experimental.ToAliasReference
     where
 
-import Data.Coerce
 import Database.Esqueleto.Internal.Internal hiding (From, from, on)
 import Database.Esqueleto.Internal.PersistentImport
 
@@ -31,7 +30,7 @@ instance ToAliasReference (SqlExpr (Entity a)) where
 
 instance ToAliasReference (SqlExpr (Maybe (Entity a))) where
     toAliasReference aliasSource e =
-        coerce <$> toAliasReference aliasSource (coerce e :: SqlExpr (Entity a))
+        veryUnsafeCoerceSqlExpr <$> toAliasReference aliasSource (veryUnsafeCoerceSqlExpr e :: SqlExpr (Entity a))
 
 
 instance (ToAliasReference a, ToAliasReference b) => ToAliasReference (a, b) where

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -2349,6 +2349,8 @@ entityAsValueMaybe = coerce
 -- interpolated by the SQL backend.
 data SqlExpr a = ERaw SqlExprMeta (NeedParens -> IdentInfo -> (TLB.Builder, [PersistValue]))
 
+type role SqlExpr nominal
+
 -- | Folks often want the ability to promote a Haskell function into the
 -- 'SqlExpr' expression language - and naturally reach for 'fmap'.
 -- Unfortunately, this is impossible. We cannot send *functions* to the

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -2360,14 +2360,19 @@ type role SqlExpr nominal
 -- There is no guarantee that the result works! To be safe, you want to provide
 -- a local helper function that calls this at a tested type.
 --
--- As an example, you may want to assert that a SQL expression is never @NULL@,
--- even though it is introduced in a way that may allow it to be @NULL@. You can
--- remove the 'Maybe' with this:
+-- As an example, you may know that two types share an identical SQL
+-- representation, and can be parsed exactly the same way. Perhaps you have
+-- a @data SomeEnum@ which you represent as a @TEXT@ in Postgres, and you
+-- want to treat it as a @TEXT@. You could define a top-level
+-- type-restricted alias to this which allows this to be done safely:
 --
 -- @
---  unsafeRemoveMaybe :: SqlExpr (Value (Maybe a)) -> SqlExpr (Value a)
---  unsafeRemoveMaybe = veryUnsafeCoerceSqlExpr
+--  enumToText :: SqlExpr (Value SomeEnum) -> SqlExpr (Value Text)
+--  enumToText = veryUnsafeCoerceSqlExpr
 -- @
+--
+-- Note that this is fragile: if you change the encoding of 'SomeEnum' to
+-- be anything other than 'Text', then your code will fail at runtime.
 --
 -- @since 3.6.0.0
 veryUnsafeCoerceSqlExpr :: SqlExpr a -> SqlExpr b


### PR DESCRIPTION
Fixes #270 and #305 

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
