### PR TITLE
Deprecate LockingKind constructors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,11 @@
         - The ability to `coerce` `SqlExpr` was removed. Instead, use
           `veryUnsafeCoerceSqlExpr`. See the documentation on
           `veryUnsafeCoerceSqlExpr` for safe use example.
+    - [#420](https://github.com/bitemyapp/esqueleto/pull/421)
+        - The `LockingKind` constructors are deprecated, and will be removed
+          from non-Internal modules in a future release. Smart constructors
+          replace them, and you may need to import them from a different
+          database-specific module.
 
 3.5.14.0
 ========

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -83,6 +83,8 @@ module Database.Esqueleto {-# WARNING "This module will switch over to the Exper
   , OrderBy
   , DistinctOn
   , LockingKind(..)
+  , forUpdate
+  , forUpdateSkipLocked
   , LockableEntity(..)
   , SqlString
     -- ** Joins

--- a/src/Database/Esqueleto/Experimental.hs
+++ b/src/Database/Esqueleto/Experimental.hs
@@ -71,6 +71,8 @@ module Database.Esqueleto.Experimental
     , distinctOnOrderBy
     , having
     , locking
+    , forUpdate
+    , forUpdateSkipLocked
 
     , (^.)
     , (?.)

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1569,6 +1569,32 @@ data LockingKind
       --
       -- @since 2.2.7
 
+{-# DEPRECATED ForUpdate, ForUpdateSkipLocked "The constructors for 'LockingKind' are deprecated in v3.6.0.0. Instead, please refer to the smart constructors 'forUpdate' and 'forUpdateSkipLocked'." #-}
+{-# DEPRECATED ForShare "The constructors for 'LockingKind' are deprecated in v3.6.0.0. Instead, please refer to the smart constructor 'forShare' exported from Database.Esqueleto.PostgreSQL." #-}
+{-# DEPRECATED LockInShareMode "The constructors for 'LockingKind' are deprecated in v3.6.0.0. Instead, please refer to the smart constructors 'lockInShareMode' exported from Database.Esqueleto.MySQL." #-}
+
+-- | @FOR UPDATE@ syntax.
+--
+-- Usage:
+--
+-- @
+--  'locking' 'forUpdate'
+-- @
+--
+-- @since 3.6.0.0
+forUpdate :: LockingKind
+forUpdate = ForUpdate
+
+-- | @FOR UPDATE SKIP LOCKED@ syntax.
+--
+-- @
+--  'locking' 'forUpdateSkipLocked'
+-- @
+--
+-- @since 3.6.0.0
+forUpdateSkipLocked :: LockingKind
+forUpdateSkipLocked = ForUpdateSkipLocked
+
 -- | Postgres specific locking, used only internally
 --
 -- @since 3.5.9.0

--- a/src/Database/Esqueleto/Legacy.hs
+++ b/src/Database/Esqueleto/Legacy.hs
@@ -84,6 +84,8 @@ module Database.Esqueleto.Legacy
   , OrderBy
   , DistinctOn
   , LockingKind(..)
+  , forUpdate
+  , forUpdateSkipLocked
   , LockableEntity(..)
   , SqlString
     -- ** Joins

--- a/src/Database/Esqueleto/MySQL.hs
+++ b/src/Database/Esqueleto/MySQL.hs
@@ -5,6 +5,7 @@
 -- @since 2.2.8
 module Database.Esqueleto.MySQL
     ( random_
+    , lockInShareMode
     ) where
 
 import Database.Esqueleto.Internal.Internal hiding (random_)
@@ -13,6 +14,18 @@ import Database.Esqueleto.Internal.PersistentImport
 -- | (@random()@) Split out into database specific modules
 -- because MySQL uses `rand()`.
 --
--- /Since: 2.6.0/
+-- @since 2.6.0
 random_ :: (PersistField a, Num a) => SqlExpr (Value a)
 random_ = unsafeSqlValue "RAND()"
+
+-- | @LOCK IN SHARE MODE@ syntax.
+--
+-- Example:
+--
+-- @
+--  'locking' 'lockInShareMode'
+-- @
+--
+-- @since 3.6.0.0
+lockInShareMode :: LockingKind
+lockInShareMode = LockInShareMode

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -34,6 +34,7 @@ module Database.Esqueleto.PostgreSQL
     , skipLocked
     , forUpdateOf
     , forNoKeyUpdateOf
+    , forShare
     , forShareOf
     , forKeyShareOf
     , filterWhere
@@ -653,6 +654,18 @@ forNoKeyUpdateOf lockableEntities onLockedBehavior =
 forShareOf :: LockableEntity a => a -> OnLockedBehavior -> SqlQuery ()
 forShareOf lockableEntities onLockedBehavior =
   putLocking $ PostgresLockingClauses [PostgresLockingKind PostgresForShare (Just $ LockingOfClause lockableEntities) onLockedBehavior]
+
+-- | @FOR SHARE@ syntax for Postgres locking.
+--
+-- Example use:
+--
+-- @
+--  'locking' 'forShare'
+-- @
+--
+-- @since 3.6.0.0
+forShare :: LockingKind
+forShare = ForShare
 
 -- | `FOR KEY SHARE OF` syntax for postgres locking
 -- allows locking of specific tables with a key share lock in a view or join


### PR DESCRIPTION
This PR deprecates the `LockingKind` constructors as they will be removed from non-`Internal` module in a future release. Smart constructors are provided as alternatives.

Fixes #319 

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
