### PR TITLE
cherry pick nullable field projection to 3.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,65 @@
+<<<<<<< HEAD
+=======
+3.6.0.0
+=======
+- @parsonsmatt
+    - [#422](https://github.com/bitemyapp/esqueleto/pull/422)
+        - The instance of `HasField` for `SqlExpr (Maybe (Entity a))` joins
+          `Maybe` values together. This means that if you `leftJoin` a table
+          with a `Maybe` column, the result will be a `SqlExpr (Value (Maybe
+          typ))`, instead of `SqlExpr (Value (Maybe (Maybe typ)))`.
+        - To make this a less breaking change, `joinV` has been given a similar
+          behavior. If the input type to `joinV` is `Maybe (Maybe typ)`, then
+          the result becomes `Maybe typ`. If the input type is `Maybe typ`, then
+          the output is also `Maybe typ`.
+        - The `just` function is also modified to avoid nesting `Maybe`.
+    - [#420](https://github.com/bitemyapp/esqueleto/pull/420)
+        - Add a fixity declaration to `?.`
+    - [#412](https://github.com/bitemyapp/esqueleto/pull/412)
+        - The `random_` and `rand` functions (deprecated in 2.6.0) have been
+          removed. Please refer to the database specific ones (ie
+          `Database.Esqueleto.PostgreSQL` etc)
+        - The `sub_select` function (deprecated in 3.2.0) has been removed.
+          Please use the safer variants like `subSelect`, `subSelectMaybe`, etc.
+        - The `ToAliasT` and `ToAliasReferenceT` types has been removed after having been deprecated in 3.4.0.1.
+        - The `Union` type (deprecated in 3.4) was removed. Please use `union_`
+          instead.
+        - The `UnionAll` type (deprecated in 3.4) was removed. Please use
+          `unionAll_` instead.
+        - The `Except` type  (deprecated in 3.4) was removed. Please use
+          `except_` instead.
+        - The `Intersect` type  (deprecated in 3.4) was removed. Please use
+          `intersect_` instead.
+        - The `SubQuery` type (deprecated in 3.4) was removed. You do not need
+          to tag subqueries to use them in `from` clauses.
+        - The `SelectQuery` type (deprecated in 3.4) was removed. You do not
+          need to tag `SqlQuery` values with `SelectQuery`.
+    - [#287](https://github.com/bitemyapp/esqueleto/pull/278)
+        - Deprecate `distinctOn` and `distinctOnOrderBy`. Use the variants
+          defined in `PostgreSQL` module instead. The signature has changed, but
+          the refactor is straightforward:
+          ```
+              -- old:
+              p <- from $ table
+              distinctOn [don x] $ do
+                  pure p
+
+              -- new:
+              p <- from $ table
+              distinctOn [don x]
+              pure p
+          ```
+    - [#301](https://github.com/bitemyapp/esqueleto/pull/301)
+        - Postgresql `upsert` and `upsertBy` now require a `NonEmpty` list of
+          updates. If you want to provide an empty list of updates, you'll need
+          to use `upsertMaybe` and `upsertMaybeBe` instead. Postgres does not
+          return rows from the database if no updates are performed.
+    - [#413](https://github.com/bitemyapp/esqueleto/pull/413)
+        - The ability to `coerce` `SqlExpr` was removed. Instead, use
+          `veryUnsafeCoerceSqlExpr`. See the documentation on
+          `veryUnsafeCoerceSqlExpr` for safe use example.
+
+>>>>>>> cfa86bb (hmmm that works kinda nicely)
 3.5.14.0
 ========
 - @parsonsmatt

--- a/esqueleto.cabal
+++ b/esqueleto.cabal
@@ -81,6 +81,8 @@ library
         -Wcpp-undef
         -Wcpp-undef
     default-language: Haskell2010
+    default-extensions: 
+        TypeOperators
 
 test-suite specs
     type: exitcode-stdio-1.0

--- a/src/Database/Esqueleto/Experimental/ToMaybe.hs
+++ b/src/Database/Esqueleto/Experimental/ToMaybe.hs
@@ -7,10 +7,6 @@ module Database.Esqueleto.Experimental.ToMaybe
 import Database.Esqueleto.Internal.Internal hiding (From(..), from, on)
 import Database.Esqueleto.Internal.PersistentImport (Entity(..))
 
-type family Nullable a where
-    Nullable (Maybe a) = a
-    Nullable a =  a
-
 class ToMaybe a where
     type ToMaybeT a
     toMaybe :: a -> ToMaybeT a

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -690,9 +690,6 @@ just
     -> SqlExpr (Value (Maybe typ))
 just = veryUnsafeCoerceSqlExprValue
 
-justNullable :: SqlExpr (Value typ) -> SqlExpr (Value (Maybe (Nullable typ)))
-justNullable = veryUnsafeCoerceSqlExprValue
-
 -- | @NULL@ value.
 nothing :: SqlExpr (Value (Maybe typ))
 nothing = unsafeSqlValue "NULL"
@@ -700,8 +697,8 @@ nothing = unsafeSqlValue "NULL"
 -- | Join nested 'Maybe's in a 'Value' into one. This is useful when
 -- calling aggregate functions on nullable fields.
 joinV
-    :: SqlExpr (Value (Maybe typ))
-    -> SqlExpr (Value (Maybe (Nullable typ)))
+    :: SqlExpr (Value (Maybe (Maybe typ)))
+    -> SqlExpr (Value (Maybe typ))
 joinV = veryUnsafeCoerceSqlExprValue
 
 

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -694,7 +694,10 @@ nothing = unsafeSqlValue "NULL"
 
 -- | Join nested 'Maybe's in a 'Value' into one. This is useful when
 -- calling aggregate functions on nullable fields.
-joinV :: SqlExpr (Value (Maybe (Maybe typ))) -> SqlExpr (Value (Maybe typ))
+joinV
+    :: NullableFieldProjection typ typ'
+    => SqlExpr (Value (Maybe typ))
+    -> SqlExpr (Value (Maybe typ'))
 joinV = veryUnsafeCoerceSqlExprValue
 
 

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -680,7 +680,12 @@ isNothing_ = isNothing
 -- | Analogous to 'Just', promotes a value of type @typ@ into
 -- one of type @Maybe typ@.  It should hold that @'val' . Just
 -- === just . 'val'@.
-just :: SqlExpr (Value typ) -> SqlExpr (Value (Maybe typ))
+--
+-- This function will not produce a nested 'Maybe'. This is in accord with
+-- how SQL represents @NULL@. That means that @'just' . 'just' = 'just'@.
+just
+    :: (NullableFieldProjection typ typ')
+    => SqlExpr (Value typ) -> SqlExpr (Value (Maybe typ'))
 just = veryUnsafeCoerceSqlExprValue
 
 -- | @NULL@ value.
@@ -2472,11 +2477,41 @@ instance
 --
 -- @since 3.5.4.0
 instance
-    (PersistEntity rec, PersistField typ, SymbolToField sym rec typ)
+    (PersistEntity rec, PersistField typ, PersistField typ', SymbolToField sym rec typ
+    , NullableFieldProjection typ typ'
+    , HasField sym (SqlExpr (Maybe (Entity rec))) (SqlExpr (Value (Maybe typ')))
+    )
   =>
-    HasField sym (SqlExpr (Maybe (Entity rec))) (SqlExpr (Value (Maybe typ)))
+    HasField sym (SqlExpr (Maybe (Entity rec))) (SqlExpr (Value (Maybe typ')))
   where
-    getField expr = expr ?. symbolToField @sym
+    getField expr = veryUnsafeCoerceSqlExprValue (expr ?. symbolToField @sym)
+
+-- | The 'NullableFieldProjection' type is used to determine whether
+-- a 'Maybe' should be stripped off or not. This is used in the 'HasField'
+-- for @'SqlExpr' ('Maybe' ('Entity' a))@ to allow you to only have
+-- a single level of 'Maybe'.
+--
+-- @
+-- MyTable
+--   column         Int Maybe
+--   someTableId    SomeTableId
+--
+--  select $ do
+--      (_ :& maybeMyTable) <-
+--          from $ table @SomeTable
+--              `leftJoin` table @MyTable
+--                  `on` do
+--                      \(someTable :& maybeMyTable) ->
+--                          just someTable.id ==. maybeMyTable.someTableId
+--        where_ $ maybeMyTable.column ==. just (val 10)
+--        pure maybeMyTable
+-- @
+--
+-- Without this class, projecting a field with type @'Maybe' typ@ would
+-- have resulted in a @'SqlExpr' ('Value' ('Maybe' ('Maybe' typ)))@.
+class NullableFieldProjection typ typ'
+instance {-# incoherent #-} (typ ~ typ') => NullableFieldProjection (Maybe typ) typ'
+instance {-# overlappable #-} (typ ~ typ') => NullableFieldProjection typ typ'
 
 -- | Data type to support from hack
 data PreprocessedFrom a = PreprocessedFrom a FromClause

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -472,7 +472,7 @@ sub_select         = sub SELECT
 subSelect
   :: PersistField a
   => SqlQuery (SqlExpr (Value a))
-  -> SqlExpr (Value (Maybe (Nullable a)))
+  -> SqlExpr (Value (Maybe a))
 subSelect query = just (subSelectUnsafe (query <* limit 1))
 
 -- | Execute a subquery @SELECT@ in a 'SqlExpr'. This function is a shorthand
@@ -486,7 +486,7 @@ subSelect query = just (subSelectUnsafe (query <* limit 1))
 subSelectMaybe
     :: PersistField a
     => SqlQuery (SqlExpr (Value (Maybe a)))
-    -> SqlExpr (Value (Maybe (Nullable a)))
+    -> SqlExpr (Value (Maybe a))
 subSelectMaybe = joinV . subSelect
 
 -- | Performs a @COUNT@ of the given query in a @subSelect@ manner. This is
@@ -687,8 +687,11 @@ isNothing_ = isNothing
 -- how SQL represents @NULL@. That means that @'just' . 'just' = 'just'@.
 just
     :: SqlExpr (Value typ)
-    -> SqlExpr (Value (Maybe (Nullable typ)))
+    -> SqlExpr (Value (Maybe typ))
 just = veryUnsafeCoerceSqlExprValue
+
+justNullable :: SqlExpr (Value typ) -> SqlExpr (Value (Maybe (Nullable typ)))
+justNullable = veryUnsafeCoerceSqlExprValue
 
 -- | @NULL@ value.
 nothing :: SqlExpr (Value (Maybe typ))
@@ -958,7 +961,7 @@ coalesce              = unsafeSqlFunctionParens "COALESCE"
 -- a non-NULL result.
 --
 -- @since 1.4.3
-coalesceDefault :: PersistField a => [SqlExpr (Value (Maybe (Nullable a)))] -> SqlExpr (Value a) -> SqlExpr (Value a)
+coalesceDefault :: PersistField a => [SqlExpr (Value (Maybe a))] -> SqlExpr (Value a) -> SqlExpr (Value a)
 coalesceDefault exprs = unsafeSqlFunctionParens "COALESCE" . (exprs ++) . return . just
 
 -- | @LOWER@ function.

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -470,9 +470,9 @@ sub_select         = sub SELECT
 --
 -- @since 3.2.0
 subSelect
-  :: PersistField a
+  :: (PersistField a, NullableFieldProjection a a')
   => SqlQuery (SqlExpr (Value a))
-  -> SqlExpr (Value (Maybe a))
+  -> SqlExpr (Value (Maybe a'))
 subSelect query = just (subSelectUnsafe (query <* limit 1))
 
 -- | Execute a subquery @SELECT@ in a 'SqlExpr'. This function is a shorthand
@@ -626,10 +626,10 @@ withNonNull field f = do
 -- | Project a field of an entity that may be null.
 --
 -- This will not produce a nested 'Maybe'.
-(?.) :: (PersistEntity val , PersistField typ, NullableFieldProjection typ typ')
+(?.) :: (PersistEntity val, PersistField typ)
     => SqlExpr (Maybe (Entity val))
     -> EntityField val typ
-    -> SqlExpr (Value (Maybe typ'))
+    -> SqlExpr (Value (Maybe (Nullable typ)))
 ERaw m f ?. field = veryUnsafeCoerceSqlExprValue (ERaw m f ^. field)
 
 -- | Lift a constant value from Haskell-land to the query.
@@ -686,8 +686,9 @@ isNothing_ = isNothing
 -- This function will not produce a nested 'Maybe'. This is in accord with
 -- how SQL represents @NULL@. That means that @'just' . 'just' = 'just'@.
 just
-    :: SqlExpr (Value typ)
-    -> SqlExpr (Value (Maybe typ))
+    :: (NullableFieldProjection typ typ')
+    => SqlExpr (Value typ)
+    -> SqlExpr (Value (Maybe typ'))
 just = veryUnsafeCoerceSqlExprValue
 
 -- | @NULL@ value.
@@ -697,8 +698,9 @@ nothing = unsafeSqlValue "NULL"
 -- | Join nested 'Maybe's in a 'Value' into one. This is useful when
 -- calling aggregate functions on nullable fields.
 joinV
-    :: SqlExpr (Value (Maybe (Maybe typ)))
-    -> SqlExpr (Value (Maybe typ))
+    :: (NullableFieldProjection typ typ')
+    => SqlExpr (Value (Maybe typ))
+    -> SqlExpr (Value (Maybe typ'))
 joinV = veryUnsafeCoerceSqlExprValue
 
 
@@ -2489,7 +2491,7 @@ instance
   =>
     HasField sym (SqlExpr (Maybe (Entity rec))) (SqlExpr (Value (Maybe typ')))
   where
-    getField expr = expr ?. symbolToField @sym
+    getField expr = veryUnsafeCoerceSqlExprValue (expr ?. symbolToField @sym)
 
 -- | The 'NullableFieldProjection' type is used to determine whether
 -- a 'Maybe' should be stripped off or not. This is used in the 'HasField'
@@ -2516,7 +2518,7 @@ instance
 -- have resulted in a @'SqlExpr' ('Value' ('Maybe' ('Maybe' typ)))@.
 class NullableFieldProjection typ typ'
 instance {-# incoherent #-} (typ ~ typ') => NullableFieldProjection (Maybe typ) typ'
-instance {-# overlappable #-} (typ ~ typ') => NullableFieldProjection typ typ'
+instance (typ ~ typ') => NullableFieldProjection typ typ'
 
 type family Nullable a where
     Nullable (Maybe a) = a

--- a/src/Database/Esqueleto/PostgreSQL.hs
+++ b/src/Database/Esqueleto/PostgreSQL.hs
@@ -173,7 +173,7 @@ stringAggWith ::
   -> SqlExpr (Value s) -- ^ Input values.
   -> SqlExpr (Value s) -- ^ Delimiter.
   -> [OrderByClause] -- ^ ORDER BY clauses
-  -> SqlExpr (Value (Maybe s)) -- ^ Concatenation.
+  -> SqlExpr (Value (Maybe (Nullable s))) -- ^ Concatenation.
 stringAggWith mode expr delim os =
   unsafeSqlAggregateFunction "string_agg" mode (expr, delim) os
 
@@ -185,7 +185,7 @@ stringAgg ::
      SqlString s
   => SqlExpr (Value s) -- ^ Input values.
   -> SqlExpr (Value s) -- ^ Delimiter.
-  -> SqlExpr (Value (Maybe s)) -- ^ Concatenation.
+  -> SqlExpr (Value (Maybe (Nullable s))) -- ^ Concatenation.
 stringAgg expr delim = stringAggWith AggModeAll expr delim []
 
 -- | (@chr@) Translate the given integer to a character. (Note the result will

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.13
+resolver: lts-22.04
 
 packages:
   - '.'
@@ -8,7 +8,6 @@ allow-newer: true
 
 extra-deps:
 - lift-type-0.1.0.1
-- persistent-2.14.0.2
 
 nix:
   packages: [zlib, libmysqlclient, pcre, postgresql]

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -2545,6 +2545,20 @@ testOverloadedRecordDot = describe "OverloadedRecordDot" $ do
                                 just p.id ==. mbp.authorId
                 pure (p.id, mbp.title)
 
+    itDb "joins Maybe together" $ do
+        void $ select $ do
+            deed :& lord <-
+                Experimental.from $
+                    table @Deed
+                    `leftJoin` table @Lord
+                        `Experimental.on` do
+                            \(deed :& lord) ->
+                                lord.id ==. just deed.ownerId
+            where_ $ lord.dogs >=. just (val 10)
+            where_ $ joinV lord.dogs >=. just (just (val 10))
+            where_ $ lord.dogs >=. just (val (Just 10))
+            pure lord
+
 #else
     it "is only supported in GHC 9.2 or above" $ \_ -> do
         pending

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -980,7 +980,7 @@ testSelectWhere = describe "select where_" $ do
         _ <- insert' p4
         ret <- select $
                from $ \p->
-               return $ joinV $ min_ (p ^. PersonAge)
+               return $ min_ (p ^. PersonAge)
         asserting $ ret `shouldBe` [ Value $ Just (17 :: Int) ]
 
     itDb "works with max_" $ do
@@ -990,7 +990,7 @@ testSelectWhere = describe "select where_" $ do
         _ <- insert' p4
         ret <- select $
                from $ \p->
-               return $ joinV $ max_ (p ^. PersonAge)
+               return $ max_ (p ^. PersonAge)
         asserting $ ret `shouldBe` [ Value $ Just (36 :: Int) ]
 
     itDb "works with lower_" $ do
@@ -2587,3 +2587,5 @@ testGetTable =
                 pure (person, blogPost, profile, reply)
             asserting noExceptions
 
+joinTypeTests :: IO ()
+joinTypeTests = pure ()

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -543,8 +544,8 @@ testSelectJoin = do
         b31e <- insert' $ BlogPost "c" (entityKey p3e)
         ret <- select $
                from $ \(p `LeftOuterJoin` mb) -> do
-               on (just (p ^. PersonId) ==. mb ?. BlogPostAuthorId)
-               orderBy [ asc (p ^. PersonName), asc (mb ?. BlogPostTitle) ]
+               on (just (p ^. PersonId) ==. mb ?. #authorId)
+               orderBy [ asc (p ^. PersonName), asc (mb ?. #title) ]
                return (p, mb)
         asserting $ ret `shouldBe` [ (p1e, Just b11e)
                                 , (p1e, Just b12e)
@@ -578,6 +579,20 @@ testSelectJoin = do
            orderBy [ asc (p ^. PersonName), asc (mb ?. BlogPostTitle) ]
            return (p, mb)
       asserting $ shouldBeOnClauseWithoutMatchingJoinException eres
+
+    itDb "i didn't bork ?." $ do
+        weights <- select $ do
+            (pro :& per) <- Experimental.from $
+                table @Profile
+                    `leftJoin` table @Person
+                        `Experimental.on` do
+                            \(pro :& per) ->
+                                just (pro ^. #person) ==. per ?. #id
+                                &&. just pro.person ==. per ?. PersonId
+            pure $ per ?. #weight
+        asserting $ do
+            weights `shouldBe` ([] :: [Value (Maybe Int)])
+
 
     itDb "throws an error for using too many ons" $ do
       eres <- try $ select $
@@ -2527,7 +2542,7 @@ shouldBeOnClauseWithoutMatchingJoinException ea =
             expectationFailure $ "Expected OnClauseWithMatchingJoinException, got: " <> show ea
 
 testOverloadedRecordDot :: SpecDb
-testOverloadedRecordDot = describe "OverloadedRecordDot" $ do
+testOverloadedRecordDot = focus $ describe "OverloadedRecordDot" $ do
 #if __GLASGOW_HASKELL__ >= 902
     describe "with SqlExpr (Entity rec)" $ do
         itDb "lets you project from a record" $ do
@@ -2545,19 +2560,58 @@ testOverloadedRecordDot = describe "OverloadedRecordDot" $ do
                                 just p.id ==. mbp.authorId
                 pure (p.id, mbp.title)
 
-    itDb "joins Maybe together" $ do
-        void $ select $ do
-            deed :& lord <-
-                Experimental.from $
-                    table @Deed
-                    `leftJoin` table @Lord
+    describe "Type Inference and Maybe" $ do
+        itDb "joins Maybe together" $ do
+            void $ select $ do
+                deed :& lord :& user :& address <-
+                    Experimental.from $
+                        table @Deed
+                        `leftJoin` table @Lord
+                            `Experimental.on` do
+                                \(deed :& lord) ->
+                                    lord.id ==. just deed.ownerId
+                        `leftJoin` table @User
+                            `Experimental.on` do
+                                \(_ :& lord :& user) ->
+                                    lord.county ==. user.name
+                        `leftJoin` table @Address
+                            `Experimental.on` do
+                                \(_ :& user :& address) ->
+                                    user.address ==. address.id
+                where_ $ lord.dogs >=. just (just (val 10))
+                where_ $ joinV lord.dogs >=. just (just (val 10))
+                where_ $ lord.dogs >=. just (val (Just 10))
+                where_ $ lord.dogs >=. just (val 10)
+                -- where_ $ lord.dogs >=. val 10 -- this fails with a type error, as expected
+                pure (lord, user.address, address.address)
+
+        itDb "" $ void $ do
+            select $ do
+                (p :& bp :& c) <- Experimental.from $
+                    table @Person
+                    `leftJoin` table @BlogPost
                         `Experimental.on` do
-                            \(deed :& lord) ->
-                                lord.id ==. just deed.ownerId
-            where_ $ lord.dogs >=. just (val 10)
-            where_ $ joinV lord.dogs >=. just (just (val 10))
-            where_ $ lord.dogs >=. just (val (Just 10))
-            pure lord
+                            \(p :& bp) ->
+                                just p.id ==. bp.authorId
+                                -- this has a bad type error. "can't match
+                                -- `Maybe typ'` with `Key Person`". no good
+                                -- indication that the problem is that
+                                -- `bp.authorId` has type `Maybe _` and
+                                -- that's why.
+                                -- p.id ==. bp.authorId
+                    `leftJoin` table @Comment
+                        `Experimental.on` do
+                            \(_ :& bp :& c) ->
+                                bp.id ==. c.blog
+                                &&. bp ?. #id ==. c ?. #blog
+                where_ $ p.id ==. val undefined
+                where_ $ c.title ==. just (val "hello")
+                where_ $ c.title ==. just (just (val "hello"))
+                where_ $ c ?. #title ==. just (val "hello")
+                -- this gives "no instance IsSTring (Maybe [Char])" which
+                -- is great for type inference
+                -- where_ $ c ?. #title ==. (val "hello")
+                pure (p, bp, c)
 
 #else
     it "is only supported in GHC 9.2 or above" $ \_ -> do
@@ -2583,7 +2637,7 @@ testGetTable =
                         `leftJoin` table @Reply
                             `Experimental.on` do
                                 \((getTable @Person -> p) :& reply) ->
-                                    just (p ^. PersonId) ==. reply ?. ReplyGuy
+                                    just (p ^. PersonId) ==. reply ?. #guy
                 pure (person, blogPost, profile, reply)
             asserting noExceptions
 

--- a/test/Common/Test/Models.hs
+++ b/test/Common/Test/Models.hs
@@ -61,6 +61,7 @@ share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistUpperCase|
     deriving Eq Show
   Comment
     body String
+    title String Maybe
     blog BlogPostId
     deriving Eq Show
   CommentReply


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
