### PR TITLE
Fix typos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -97,7 +97,7 @@
 ========
 - @blujupiter32
     - [#379](https://github.com/bitemyapp/esqueleto/pull/379)
-        - Fix a bug where `not_ (a &&. b)` would be interpeted as `(not_ a) &&. b`
+        - Fix a bug where `not_ (a &&. b)` would be interpreted as `(not_ a) &&. b`
 - @RikvanToor
     - [#373](https://github.com/bitemyapp/esqueleto/pull/373), [#410](https://github.com/bitemyapp/esqueleto/pull/410)
         - Fix name clashes when using CTEs multiple times
@@ -288,7 +288,7 @@
 =======
 - @m4dc4p
   - [#291](https://github.com/bitemyapp/esqueleto/pull/291)
-         - Added `ToAlias` and `ToAliasReference` instaces to the `:&` type, mirroring
+         - Added `ToAlias` and `ToAliasReference` instances to the `:&` type, mirroring
          the tuple instances for the same classes. See [Issue #290](https://github.com/bitemyapp/esqueleto/issues/290)
          for discussion.
 - @NikitaRazmakhnin
@@ -300,7 +300,7 @@
 =======
 - @NikitaRazmakhnin
   - [#278](https://github.com/bitemyapp/esqueleto/pull/278)
-        - Fix generating of bad sql using nexted expressions with `distinctOnOrderBy`.
+        - Fix generating of bad sql using nested expressions with `distinctOnOrderBy`.
 
 3.5.2.1
 =======
@@ -398,7 +398,7 @@
   - [#215](https://github.com/bitemyapp/esqueleto/pull/215)
     - Added support for common table expressions (`with`, `withRecursive`)
     - Added support for lateral JOINs with updated example (Example #6)
-    - Deprecated `SelectQuery`, removing the neccessity to tag `SqlQuery` values
+    - Deprecated `SelectQuery`, removing the necessity to tag `SqlQuery` values
     - Deprecated use of data constructors for SQL set operations (replaced with functions)
     - Refactored module structure to fix haddock build (fixes build from `3.3.4.0`)
 

--- a/src/Database/Esqueleto.hs
+++ b/src/Database/Esqueleto.hs
@@ -388,7 +388,7 @@ import Database.Esqueleto.Internal.PersistentImport
 
 -- $reexports
 --
--- We re-export many symbols from @persistent@ for convenince:
+-- We re-export many symbols from @persistent@ for convenience:
 --
 --  * \"Store functions\" from "Database.Persist".
 --

--- a/src/Database/Esqueleto/Experimental/From.hs
+++ b/src/Database/Esqueleto/Experimental/From.hs
@@ -101,7 +101,7 @@ table = From $ do
 instance (SqlSelect a r, ToAlias a, ToAliasReference a) => ToFrom (SqlQuery a) a where
     toFrom = selectQuery
 
--- | Select from a subquery, often used in conjuction with joins but can be
+-- | Select from a subquery, often used in conjunction with joins but can be
 -- used without any joins. Because @SqlQuery@ has a @ToFrom@ instance you probably
 -- dont need to use this function directly.
 --

--- a/src/Database/Esqueleto/Experimental/From/Join.hs
+++ b/src/Database/Esqueleto/Experimental/From/Join.hs
@@ -29,7 +29,7 @@ module Database.Esqueleto.Experimental.From.Join
     , GetFirstTable(..)
     , getTable
     , getTableMaybe
-    -- Compatability for old syntax
+    -- Compatibility for old syntax
     , Lateral
     , NotLateral
     , IsLateral

--- a/src/Database/Esqueleto/Experimental/ToAlias.hs
+++ b/src/Database/Esqueleto/Experimental/ToAlias.hs
@@ -27,7 +27,7 @@ instance ToAlias (SqlExpr (Entity a)) where
            pure $ ERaw m{sqlExprMetaIsReference = False, sqlExprMetaAlias = Just ident} f
 
 instance ToAlias (SqlExpr (Maybe (Entity a))) where
-    -- FIXME: Code duplication because the compiler doesnt like half final encoding
+    -- FIXME: Code duplication because the compiler doesn't like half final encoding
     toAlias e@(ERaw m f)
       | Just _ <- sqlExprMetaAlias m = pure e
       | otherwise = do

--- a/src/Database/Esqueleto/Internal/Internal.hs
+++ b/src/Database/Esqueleto/Internal/Internal.hs
@@ -1744,7 +1744,7 @@ data LockingOfClause where
 data OnLockedBehavior =
     NoWait
     -- ^ @NOWAIT@ syntax locking behaviour.
-    --  query excutes immediately failing on locked rows
+    --  query executes immediately failing on locked rows
     --
     -- @since 3.5.9.0
       | SkipLocked
@@ -2478,7 +2478,7 @@ entityAsValueMaybe = veryUnsafeCoerceSqlExpr
 -- | An expression on the SQL backend.
 --
 -- Raw expression: Contains a 'SqlExprMeta' and a function for
--- building the expr. It recieves a parameter telling it whether
+-- building the expr. It receives a parameter telling it whether
 -- it is in a parenthesized context, and takes information about the SQL
 -- connection (mainly for escaping names) and returns both an
 -- string ('TLB.Builder') and a list of values to be
@@ -4372,7 +4372,7 @@ deleteKey = Database.Persist.delete
 --
 -- We can write @'fmap' 'associateJoin'@ and it will translate it into a 'Map'
 -- that is keyed on the 'Key' of the left 'Entity', and the value is a tuple of
--- the entity's value as well as the list of each coresponding entity.
+-- the entity's value as well as the list of each corresponding entity.
 --
 -- @
 -- getFoosAndNestedBarsFromParentHaskellese

--- a/src/Database/Esqueleto/Legacy.hs
+++ b/src/Database/Esqueleto/Legacy.hs
@@ -389,7 +389,7 @@ import Database.Esqueleto.Internal.PersistentImport
 
 -- $reexports
 --
--- We re-export many symbols from @persistent@ for convenince:
+-- We re-export many symbols from @persistent@ for convenience:
 --
 --  * \"Store functions\" from "Database.Persist".
 --

--- a/src/Database/Esqueleto/PostgreSQL/JSON.hs
+++ b/src/Database/Esqueleto/PostgreSQL/JSON.hs
@@ -394,7 +394,7 @@ infixl 6 ||., -., --., #-.
 -- will be inserted into the array; either on the left or right, depending
 -- on the position relative to the operator.
 --
--- When concatening an object with a scalar value, an exception is thrown.
+-- When concatenating an object with a scalar value, an exception is thrown.
 --
 -- @
 -- {"a": 3.14}                    || {"b": true}         == {"a": 3.14, "b": true}
@@ -497,7 +497,7 @@ infixl 6 ||., -., --., #-.
 --
 -- This is the same operator internally as `-.`, but the option to use a @text
 -- array@, instead of @text@ or @integer@ was only added in version 10.
--- That's why this function is seperate from `-.`
+-- That's why this function is separate from `-.`
 --
 -- NOTE: The following is equivalent:
 --

--- a/test/Common/Test.hs
+++ b/test/Common/Test.hs
@@ -866,7 +866,7 @@ testSelectWhere = describe "select where_" $ do
                 where_ ((p ^. PersonAge) `between` (just $ val 20, just $ val 40))
                 return p
             asserting $ ret `shouldBe` [ p1e ]
-        itDb "works for a proyected fields value" $ do
+        itDb "works for a protected fields value" $ do
             _ <- insert' p1 >> insert' p2 >> insert' p3
             ret <-
               select $
@@ -1150,7 +1150,7 @@ testAscRandom rand' = describe "random_" $
           return (p ^. PersonId :: SqlExpr (Value PersonId))
         -- There are 2^4 = 16 possible orderings.  The chance
         -- of 11 random samplings returning the same ordering
-        -- is 1/2^40, so this test should pass almost everytime.
+        -- is 1/2^40, so this test should pass almost every time.
         asserting $ S.size rets `shouldSatisfy` (>2)
 
 testSelectDistinct :: SpecDb
@@ -2320,7 +2320,7 @@ testExperimentalFrom = do
     itDb "can call functions on aliased values" $ do
         insert_ p1
         insert_ p3
-        -- Pretend this isnt all posts
+        -- Pretend this isn't all posts
         upperNames <- select $ do
           author <- Experimental.from $ Experimental.from $ Table @Person
           pure $ upper_ $ author ^. PersonName
@@ -2328,7 +2328,7 @@ testExperimentalFrom = do
         asserting $ upperNames `shouldMatchList` [ Value "JOHN"
                                               , Value "MIKE"
                                               ]
-    itDb "allows re-using (:&) joined tables" $ do
+    itDb "allows reusing (:&) joined tables" $ do
       let q = do
               result@(persons :& profiles :& posts) <-
                 Experimental.from $  Table @Person

--- a/test/PostgreSQL/Test.hs
+++ b/test/PostgreSQL/Test.hs
@@ -1551,7 +1551,7 @@ testPostgresqlLocking = do
 
             asserting noExceptions
 
--- Since lateral queries arent supported in Sqlite or older versions of mysql
+-- Since lateral queries aren't supported in Sqlite or older versions of mysql
 -- the test is in the Postgres module
 testLateralQuery :: SpecDb
 testLateralQuery = do
@@ -1645,12 +1645,12 @@ testValuesExpression = do
 testSubselectAliasingBehavior :: SpecDb
 testSubselectAliasingBehavior = do
     describe "Aliasing behavior" $ do
-        itDb "correctly realiases entities accross multiple subselects" $ do
+        itDb "correctly realiases entities across multiple subselects" $ do
             _ <- select $ do
                     Experimental.from $ Experimental.from $ Experimental.from $ table @Lord
             asserting noExceptions
 
-        itDb "doesnt erroneously repeat variable names when using subselect + union" $ do
+        itDb "doesn't erroneously repeat variable names when using subselect + union" $ do
             let lordQuery = do
                     l <- Experimental.from $ table @Lord
                     pure (l ^. LordCounty, l ^. LordDogs)


### PR DESCRIPTION
Found via `codespell -L notin,tupe,vart,te,shouldbe,ons,retart`

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
